### PR TITLE
Fixed compile issue relating to renamed security library

### DIFF
--- a/spring-boot-vaadin/pom.xml
+++ b/spring-boot-vaadin/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>spring-security-vaadin</artifactId>
+            <artifactId>spring-vaadin-security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
The spring-security-vaadin library was renamed to spring-vaadin-security, but the pom.xml in the spring-boot-vaadin subproject did not get updated it seems.  This means that it was impossible to build the project.  I have updated the pom.xml to reflect the security library's new name.
