### PR TITLE
Fix flaw in presenter that could cause unintended shared state.

### DIFF
--- a/spring-vaadin-mvp/src/main/java/org/vaadin/spring/navigator/Presenter.java
+++ b/spring-vaadin-mvp/src/main/java/org/vaadin/spring/navigator/Presenter.java
@@ -7,9 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.vaadin.spring.events.EventBus;
-import org.vaadin.spring.events.EventBusScope;
-import org.vaadin.spring.events.EventScope;
-
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewProvider;
 
@@ -31,7 +28,6 @@ public abstract class Presenter<V extends View> {
     private SpringViewProvider viewProvider;
 
     @Autowired
-    @EventBusScope(EventScope.APPLICATION)
     private EventBus eventBus;
 
     @PostConstruct

--- a/spring-vaadin-mvp/src/main/java/org/vaadin/spring/navigator/VaadinPresenter.java
+++ b/spring-vaadin-mvp/src/main/java/org/vaadin/spring/navigator/VaadinPresenter.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import org.vaadin.spring.UIScope;
 import org.vaadin.spring.VaadinComponent;
 
 /**
@@ -29,6 +30,7 @@ import org.vaadin.spring.VaadinComponent;
 @Target({java.lang.annotation.ElementType.TYPE})
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Documented
+@UIScope
 @VaadinComponent
 public @interface VaadinPresenter {
 

--- a/spring-vaadin-mvp/src/test/java/org/vaadin/spring/navigator/PresenterTest.java
+++ b/spring-vaadin-mvp/src/test/java/org/vaadin/spring/navigator/PresenterTest.java
@@ -7,8 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.vaadin.spring.events.EventBus;
-import org.vaadin.spring.events.EventBusScope;
-import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.test.VaadinAppConfiguration;
 
 
@@ -29,7 +27,6 @@ public class PresenterTest {
     private SpringViewProvider provider;
 
     @Autowired
-    @EventBusScope(EventScope.APPLICATION)
     private EventBus eventBus;
 
     @Test


### PR DESCRIPTION
Implementing this will break the `mvp-sample` here: https://github.com/peholmst/vaadin4spring/tree/master/samples/mvp-sample.  However, the fix is required so that we don't a) limit developer from using other `EventScope` with `EventBus#publish`, and b) the way the sample is structured, state is shared across browser sessions, not entirely desirable.  

I will prop updates to the `mvp-sample` to make it functional again once you accept this request.
