### PR TITLE
Fix bootstrapping of mvp-sample after update to spring-vaadin-mvp

### DIFF
--- a/samples/mvp-sample/pom.xml
+++ b/samples/mvp-sample/pom.xml
@@ -104,10 +104,6 @@
 			<artifactId>vaadin-client-compiled</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-push</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.vaadin.spring</groupId>
 			<artifactId>spring-vaadin-test</artifactId>
 			<version>${vaadin.boot.version}</version>

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/MvpUI.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/MvpUI.java
@@ -4,26 +4,21 @@ import javax.inject.Inject;
 
 import org.vaadin.spring.VaadinUI;
 import org.vaadin.spring.events.EventBus;
-import org.vaadin.spring.events.EventBusScope;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.samples.mvp.ui.presenter.Action;
 import org.vaadin.spring.samples.mvp.ui.presenter.MainPresenter;
 
-import com.vaadin.annotations.Push;
 import com.vaadin.annotations.Title;
 import com.vaadin.server.VaadinRequest;
-import com.vaadin.shared.ui.ui.Transport;
 import com.vaadin.ui.UI;
 
 @VaadinUI
 @Title("Market User Interface")
-@Push(transport = Transport.STREAMING)
 public class MvpUI extends UI {
 
     private static final long serialVersionUID = 1L;
 
     @Inject
-    @EventBusScope(EventScope.APPLICATION)
     EventBus eventBus;
 
     @Inject
@@ -31,7 +26,7 @@ public class MvpUI extends UI {
 
     @Override
     protected void init(VaadinRequest vaadinRequest) {
-        eventBus.publish(this, Action.START);
+        eventBus.publish(EventScope.SESSION, this, Action.START);
         setContent(presenter.getView());
     }
 

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/component/listener/MarketDaySelectedListener.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/component/listener/MarketDaySelectedListener.java
@@ -4,6 +4,7 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
+import org.vaadin.spring.UIScope;
 import org.vaadin.spring.VaadinComponent;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventBusScope;
@@ -13,6 +14,7 @@ import org.vaadin.spring.samples.mvp.util.SSTimeUtil;
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.Property.ValueChangeListener;
 
+@UIScope
 @VaadinComponent
 public class MarketDaySelectedListener implements ValueChangeListener {
 

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/component/listener/NavigationPanelListener.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/component/listener/NavigationPanelListener.java
@@ -2,6 +2,7 @@ package org.vaadin.spring.samples.mvp.ui.component.listener;
 
 import javax.inject.Inject;
 
+import org.vaadin.spring.UIScope;
 import org.vaadin.spring.VaadinComponent;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventBusScope;
@@ -13,6 +14,7 @@ import com.vaadin.event.ItemClickEvent;
 import com.vaadin.event.ItemClickEvent.ItemClickListener;
 import com.vaadin.shared.MouseEventDetails.MouseButton;
 
+@UIScope
 @VaadinComponent
 public class NavigationPanelListener implements ItemClickListener {
 

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/component/listener/ParticipantSelectedListener.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/component/listener/ParticipantSelectedListener.java
@@ -2,6 +2,7 @@ package org.vaadin.spring.samples.mvp.ui.component.listener;
 
 import javax.inject.Inject;
 
+import org.vaadin.spring.UIScope;
 import org.vaadin.spring.VaadinComponent;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventBusScope;
@@ -10,6 +11,7 @@ import org.vaadin.spring.events.EventScope;
 import com.vaadin.data.Property.ValueChangeEvent;
 import com.vaadin.data.Property.ValueChangeListener;
 
+@UIScope
 @VaadinComponent
 public class ParticipantSelectedListener implements ValueChangeListener {
 

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/BannerPresenter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/BannerPresenter.java
@@ -15,7 +15,7 @@ public class BannerPresenter extends Presenter<BannerView> {
     @Inject
     UserService userService;
 
-    @EventBusListenerMethod
+    @EventBusListenerMethod(filter=StartupFilter.class)
     public void onStartup(Event<Action> event) {
         getView().setUser(userService.getUserName());
     }

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/BodyPresenter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/BodyPresenter.java
@@ -1,22 +1,27 @@
 package org.vaadin.spring.samples.mvp.ui.presenter;
 
+import javax.inject.Inject;
+
 import org.vaadin.spring.events.Event;
 import org.vaadin.spring.events.EventBusListenerMethod;
+import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.navigator.Presenter;
 import org.vaadin.spring.navigator.VaadinPresenter;
 import org.vaadin.spring.samples.mvp.ui.view.BodyView;
-import org.vaadin.spring.samples.mvp.ui.view.NavigationPanelView;
-import org.vaadin.spring.samples.mvp.ui.view.TabPanelView;
-
-import com.vaadin.ui.Component;
 
 @VaadinPresenter(viewName = BodyView.NAME)
 public class BodyPresenter extends Presenter<BodyView> {
 
-    @EventBusListenerMethod
+    @Inject
+    NavigationPanelPresenter nav;
+
+    @Inject
+    TabPanelPresenter tab;
+
+    @EventBusListenerMethod(scope=EventScope.SESSION, filter=StartupFilter.class)
     public void onStartup(Event<Action> event) {
-        getView().setNavigationPanel((Component) getViewProvider().getView(NavigationPanelView.NAME));
-        getView().setTabbedPanel((Component) getViewProvider().getView(TabPanelView.NAME));
+        getView().setNavigationPanel(nav.getView());
+        getView().setTabbedPanel(tab.getView());
     }
 
 }

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/HeaderPresenter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/HeaderPresenter.java
@@ -10,7 +10,7 @@ import org.vaadin.spring.samples.mvp.ui.view.HeaderView;
 @VaadinPresenter(viewName = HeaderView.NAME)
 public class HeaderPresenter extends Presenter<HeaderView> {
 
-    @EventBusListenerMethod
+    @EventBusListenerMethod(filter=StartupFilter.class)
     public void onStartup(Event<Action> event) {
         getEventBus().publish(this, ControlsContext.empty());
     }

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/MainPresenter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/MainPresenter.java
@@ -1,13 +1,13 @@
 package org.vaadin.spring.samples.mvp.ui.presenter;
 
+import javax.inject.Inject;
+
 import org.vaadin.spring.events.Event;
 import org.vaadin.spring.events.EventBusListenerMethod;
+import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.navigator.Presenter;
 import org.vaadin.spring.navigator.VaadinPresenter;
-import org.vaadin.spring.samples.mvp.ui.view.BannerView;
-import org.vaadin.spring.samples.mvp.ui.view.BodyView;
 import org.vaadin.spring.samples.mvp.ui.view.FooterView;
-import org.vaadin.spring.samples.mvp.ui.view.HeaderView;
 import org.vaadin.spring.samples.mvp.ui.view.MainView;
 
 import com.vaadin.ui.Component;
@@ -15,11 +15,20 @@ import com.vaadin.ui.Component;
 @VaadinPresenter(viewName = MainView.NAME)
 public class MainPresenter extends Presenter<MainView> {
 
-    @EventBusListenerMethod
+    @Inject
+    BannerPresenter banner;
+
+    @Inject
+    HeaderPresenter header;
+
+    @Inject
+    BodyPresenter body;
+
+    @EventBusListenerMethod(scope=EventScope.SESSION, filter=StartupFilter.class)
     public void onStartup(Event<Action> event) {
-        getView().setBanner((Component) getViewProvider().getView(BannerView.NAME));
-        getView().setHeader((Component) getViewProvider().getView(HeaderView.NAME));
-        getView().setBody((Component) getViewProvider().getView(BodyView.NAME));
+        getView().setBanner(banner.getView());
+        getView().setHeader(header.getView());
+        getView().setBody(body.getView());
         getView().setFooter((Component) getViewProvider().getView(FooterView.NAME));
     }
 

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/NavigationPanelPresenter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/NavigationPanelPresenter.java
@@ -22,7 +22,7 @@ public class NavigationPanelPresenter extends Presenter<NavigationPanelView> {
 
     private static final String NAV_ELEMENTS_FILE = "navElements.json";
 
-    @EventBusListenerMethod
+    @EventBusListenerMethod(filter=StartupFilter.class)
     public void onStartup(Event<Action> event) {
         NavElementFactory factory = new NavElementFactory();
         getEventBus().publish(this, factory.getNavElements(NAV_ELEMENTS_FILE));

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/StartupFilter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/StartupFilter.java
@@ -1,0 +1,24 @@
+package org.vaadin.spring.samples.mvp.ui.presenter;
+import org.vaadin.spring.events.EventBusListenerMethodFilter;
+
+/**
+ * A filter for startup events.
+ * Filters methods annotated with {@link EventBusListenerMethodFilter}.
+ * @author Chris Phillipson (fastnsilver@gmail.com)
+ *
+ */
+public class StartupFilter implements EventBusListenerMethodFilter {
+
+    @Override
+    public boolean filter(Object payload) {
+        boolean result = false;
+        if (Action.class.isAssignableFrom(payload.getClass())) {
+            Action action = (Action) payload;
+            if (action.equals(Action.START)) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
A summary of what's been updated
- All component listeners are @UIScope annotated
- Presenter sub-classes that are @VaadinPresenter annotated are now @UIScope, per https://github.com/peholmst/vaadin4spring/pull/79
- Remove @Push on UI and Maven dependency on vaadin-push; not being used
