### PR TITLE
Issue 74: ensure Java 6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
 
     <properties>
         <project.build.encoding>UTF-8</project.build.encoding>
-        <project.build.target>1.7</project.build.target>
-        <project.build.source>1.7</project.build.source>
+        <project.build.target>1.6</project.build.target>
+        <project.build.source>1.6</project.build.source>
         <vaadin.version>7.3.1</vaadin.version>
         <vaadin-touchkit.version>4.0.0.beta2</vaadin-touchkit.version>
         <spring.version>4.0.6.RELEASE</spring.version>

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/Security.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/Security.java
@@ -172,15 +172,17 @@ public class Security {
             }
             return false;
         }
-        final Collection<ConfigAttribute> configAttributes = new ArrayList<>(securityConfigurationAttributes.length);
+        final Collection<ConfigAttribute> configAttributes = new ArrayList<ConfigAttribute>(securityConfigurationAttributes.length);
         for (String securityConfigString : securityConfigurationAttributes) {
             configAttributes.add(new SecurityConfig(securityConfigString));
         }
         try {
             accessDecisionManager.decide(authentication, securedObject, configAttributes);
             return true;
-        } catch (AccessDeniedException | InsufficientAuthenticationException ex) {
+        } catch (AccessDeniedException ex) {
             return false;
+        } catch (InsufficientAuthenticationException ex) {
+        	return false;
         }
     }
 

--- a/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/i18n/CompositeMessageSource.java
+++ b/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/i18n/CompositeMessageSource.java
@@ -39,7 +39,7 @@ public class CompositeMessageSource extends AbstractMessageSource implements Mes
 
     private final Collection<MessageProvider> messageProviders;
 
-    private final Map<Locale, Map<String, MessageFormat>> messageFormatCache = new ConcurrentHashMap<>();
+    private final Map<Locale, Map<String, MessageFormat>> messageFormatCache = new ConcurrentHashMap<Locale, Map<String, MessageFormat>>();
 
     /**
      * Creates a new {@code CompositeMessageSource}.
@@ -95,7 +95,7 @@ public class CompositeMessageSource extends AbstractMessageSource implements Mes
     private Map<String, MessageFormat> getMessageFormatCache(Locale locale) {
         Map<String, MessageFormat> cache = messageFormatCache.get(locale);
         if (cache == null) {
-            cache = new ConcurrentHashMap<>();
+            cache = new ConcurrentHashMap<String, MessageFormat>();
             messageFormatCache.put(locale, cache);
         }
         return cache;

--- a/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/i18n/ResourceBundleMessageProvider.java
+++ b/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/i18n/ResourceBundleMessageProvider.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.MissingResourceException;
@@ -101,8 +102,20 @@ public class ResourceBundleMessageProvider implements MessageProvider {
             if ("java.properties".equals(format)) {
                 final String resourceName = toResourceName(toBundleName(baseName, locale), "properties");
                 final InputStream stream = loader.getResourceAsStream(resourceName);
-                try (Reader reader = new InputStreamReader(stream, encoding)) {
-                    return new PropertyResourceBundle(reader);
+                if (stream == null) {
+                	return null; // Not found
+                }
+                Reader reader = null;
+                try {
+                	reader = new InputStreamReader(stream, encoding);
+                	return new PropertyResourceBundle(reader);
+                } catch (UnsupportedEncodingException ex) {
+                	stream.close();
+                	throw ex;
+                } finally {
+                	if (reader != null) {
+                		reader.close();
+                	}
                 }
             } else {
                 return super.newBundle(baseName, locale, format, loader, reload);

--- a/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/sidebar/SideBarSectionDescriptor.java
+++ b/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/sidebar/SideBarSectionDescriptor.java
@@ -42,7 +42,7 @@ public class SideBarSectionDescriptor implements Comparable<SideBarSectionDescri
     public SideBarSectionDescriptor(SideBarSection section, I18N i18n) {
         this.section = section;
         this.i18n = i18n;
-        availableUIClasses = new HashSet<>(Arrays.asList(section.ui()));
+        availableUIClasses = new HashSet<Class<? extends UI>>(Arrays.asList(section.ui()));
     }
 
     /**

--- a/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/sidebar/SideBarUtils.java
+++ b/spring-vaadin-stuff/src/main/java/org/vaadin/spring/stuff/sidebar/SideBarUtils.java
@@ -42,9 +42,9 @@ public class SideBarUtils {
 
     private final I18N i18n;
 
-    private final List<SideBarSectionDescriptor> sections = new ArrayList<>();
+    private final List<SideBarSectionDescriptor> sections = new ArrayList<SideBarSectionDescriptor>();
 
-    private final List<SideBarItemDescriptor> items = new ArrayList<>();
+    private final List<SideBarItemDescriptor> items = new ArrayList<SideBarItemDescriptor>();
 
     public SideBarUtils(ApplicationContext applicationContext, I18N i18n) {
         this.applicationContext = applicationContext;
@@ -100,7 +100,7 @@ public class SideBarUtils {
      * @see SideBarSection#ui()
      */
     public Collection<SideBarSectionDescriptor> getSideBarSections(Class<? extends UI> uiClass) {
-        List<SideBarSectionDescriptor> supportedSections = new ArrayList<>();
+        List<SideBarSectionDescriptor> supportedSections = new ArrayList<SideBarSectionDescriptor>();
         for (SideBarSectionDescriptor section : sections) {
             if (section.isAvailableFor(uiClass)) {
                 supportedSections.add(section);
@@ -116,7 +116,7 @@ public class SideBarUtils {
      * @return a collection of side bar item descriptors, never {@code null}.
      */
     public Collection<SideBarItemDescriptor> getSideBarItems(SideBarSectionDescriptor descriptor) {
-        List<SideBarItemDescriptor> supportedItems = new ArrayList<>();
+        List<SideBarItemDescriptor> supportedItems = new ArrayList<SideBarItemDescriptor>();
         for (SideBarItemDescriptor item : items) {
             if (item.isMemberOfSection(descriptor)) {
                 supportedItems.add(item);

--- a/spring-vaadin/src/main/java/org/vaadin/spring/events/internal/ListenerCollection.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/events/internal/ListenerCollection.java
@@ -32,7 +32,7 @@ import java.util.Set;
 class ListenerCollection implements Serializable {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Set<Listener> listeners = new HashSet<>();
+    private final Set<Listener> listeners = new HashSet<Listener>();
 
     /**
      * Interface defining a listener.
@@ -115,7 +115,7 @@ class ListenerCollection implements Serializable {
      * @see org.vaadin.spring.events.internal.ListenerCollection.Listener#supports(org.vaadin.spring.events.Event)
      */
     public void publish(Event<?> event) {
-        Set<Listener> interestedListeners = new HashSet<>();
+        Set<Listener> interestedListeners = new HashSet<Listener>();
         synchronized (listeners) {
             addSupportedListenersToSet(listeners, interestedListeners, event);
         }

--- a/spring-vaadin/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
@@ -92,7 +92,7 @@ public class ScopedEventBus implements EventBus, Serializable {
     @Override
     public <T> void publish(Object sender, T payload) {
         logger.debug("Publishing payload [{}] from sender [{}] on event bus [{}]", payload, sender, this);
-        listeners.publish(new Event<>(this, sender, payload));
+        listeners.publish(new Event<T>(this, sender, payload));
     }
 
     @Override

--- a/spring-vaadin/src/main/java/org/vaadin/spring/i18n/Translator.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/i18n/Translator.java
@@ -76,8 +76,8 @@ public class Translator implements Serializable {
     }
 
     private void analyzeTargetClass() {
-        translatedFields = new HashMap<>();
-        translatedMethods = new HashMap<>();
+        translatedFields = new HashMap<TranslatedProperty, Field>();
+        translatedMethods = new HashMap<TranslatedProperty, Method>();
         visitClassHierarchy(new ClassUtils.ClassVisitor() {
             @Override
             public void visit(Class<?> clazz) {

--- a/spring-vaadin/src/main/java/org/vaadin/spring/internal/BeanStore.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/internal/BeanStore.java
@@ -32,9 +32,9 @@ public class BeanStore implements Serializable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BeanStore.class);
 
-    private final Map<String, Object> objectMap = new ConcurrentHashMap<>();
+    private final Map<String, Object> objectMap = new ConcurrentHashMap<String, Object>();
 
-    private final Map<String, Runnable> destructionCallbacks = new ConcurrentHashMap<>();
+    private final Map<String, Runnable> destructionCallbacks = new ConcurrentHashMap<String, Runnable>();
 
     private final String identification;
 

--- a/spring-vaadin/src/main/java/org/vaadin/spring/internal/UIStore.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/internal/UIStore.java
@@ -41,8 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 class UIStore implements Serializable, ClientConnector.DetachListener, HttpSessionBindingListener {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Map<UIID, Map<String, Object>> objectMap = new ConcurrentHashMap<>();
-    private final Map<UIID, Map<String, Runnable>> destructionCallbackMap = new ConcurrentHashMap<>();
+    private final Map<UIID, Map<String, Object>> objectMap = new ConcurrentHashMap<UIID, Map<String, Object>>();
+    private final Map<UIID, Map<String, Runnable>> destructionCallbackMap = new ConcurrentHashMap<UIID, Map<String, Runnable>>();
 
     public UIID currentUIID() {
         final UI currentUI = UI.getCurrent();
@@ -115,7 +115,7 @@ class UIStore implements Serializable, ClientConnector.DetachListener, HttpSessi
     private Map<String, Object> getObjectMap(UIID uuid) {
         Map<String, Object> map = objectMap.get(uuid);
         if (map == null) {
-            map = new ConcurrentHashMap<>();
+            map = new ConcurrentHashMap<String, Object>();
             objectMap.put(uuid, map);
         }
         return map;
@@ -135,7 +135,7 @@ class UIStore implements Serializable, ClientConnector.DetachListener, HttpSessi
     private Map<String, Runnable> getDestructionCallbackMap(UIID uuid) {
         Map<String, Runnable> map = destructionCallbackMap.get(uuid);
         if (map == null) {
-            map = new ConcurrentHashMap<>();
+            map = new ConcurrentHashMap<String, Runnable>();
             destructionCallbackMap.put(uuid, map);
         }
         return map;

--- a/spring-vaadin/src/main/java/org/vaadin/spring/internal/VaadinUIScope.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/internal/VaadinUIScope.java
@@ -158,7 +158,7 @@ public class VaadinUIScope implements Scope, BeanFactoryPostProcessor {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(UIStore.class);
 
-        private final Map<UIID, BeanStore> beanStoreMap = new ConcurrentHashMap<>();
+        private final Map<UIID, BeanStore> beanStoreMap = new ConcurrentHashMap<UIID, BeanStore>();
 
         UIStore() {
         }

--- a/spring-vaadin/src/main/java/org/vaadin/spring/navigator/SpringViewProvider.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/navigator/SpringViewProvider.java
@@ -63,7 +63,7 @@ public class SpringViewProvider implements ViewProvider {
      */
 
     // We can have multiple views with the same view name, as long as they belong to different UI subclasses
-    private final Map<String, Set<String>> viewNameToBeanNamesMap = new ConcurrentHashMap<>();
+    private final Map<String, Set<String>> viewNameToBeanNamesMap = new ConcurrentHashMap<String, Set<String>>();
     private final ApplicationContext applicationContext;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -88,7 +88,7 @@ public class SpringViewProvider implements ViewProvider {
                 }
                 Set<String> beanNames = viewNameToBeanNamesMap.get(viewName);
                 if (beanNames == null) {
-                    beanNames = new ConcurrentSkipListSet<>();
+                    beanNames = new ConcurrentSkipListSet<String>();
                     viewNameToBeanNamesMap.put(viewName, beanNames);
                 }
                 beanNames.add(beanName);

--- a/spring-vaadin/src/main/java/org/vaadin/spring/servlet/internal/AbstractSpringAwareUIProvider.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/servlet/internal/AbstractSpringAwareUIProvider.java
@@ -37,7 +37,7 @@ public abstract class AbstractSpringAwareUIProvider extends UIProvider {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     private final WebApplicationContext webApplicationContext;
-    private final Map<String, Class<? extends UI>> pathToUIMap = new ConcurrentHashMap<>();
+    private final Map<String, Class<? extends UI>> pathToUIMap = new ConcurrentHashMap<String, Class<? extends UI>>();
 
     public AbstractSpringAwareUIProvider(WebApplicationContext webApplicationContext) {
         this.webApplicationContext = webApplicationContext;


### PR DESCRIPTION
Vaadin 7 requires officially only Java 6, so it'd be beneficial if this
great plugin also had that minimum requirement.

Replacing the try-with-resource in ResourceBundleMessageProvider I
noticed that the stream would not be closed if the encoding was unknown,
so I fixed that, too.

Didn't touch the samples.
