### PR TITLE
Fix substring off by one error in URL parsing.

### DIFF
--- a/spring-vaadin/src/main/java/org/vaadin/spring/servlet/internal/AbstractSpringAwareUIProvider.java
+++ b/spring-vaadin/src/main/java/org/vaadin/spring/servlet/internal/AbstractSpringAwareUIProvider.java
@@ -60,7 +60,7 @@ public abstract class AbstractSpringAwareUIProvider extends UIProvider {
             String path = pathInfo;
             final int indexOfBang = path.indexOf('!');
             if (indexOfBang > -1) {
-                path = path.substring(0, indexOfBang - 1);
+                path = path.substring(0, indexOfBang);
             }
 
             if (path.endsWith("/")) {


### PR DESCRIPTION
Second parameter of substring() is exclusive. (Note: The second substring below is correct since length() doesn't correspond to last index.)
