### PR TITLE
Added VaadinApplicationContext including bean autoconfiguration

### DIFF
--- a/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/VaadinAutoConfiguration.java
+++ b/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/VaadinAutoConfiguration.java
@@ -20,11 +20,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.vaadin.spring.EnableVaadin;
 import org.vaadin.spring.VaadinUI;
 import org.vaadin.spring.boot.config.StaticContentVaadinServletConfiguration;
+import org.vaadin.spring.boot.context.VaadinApplicationContext;
 
 /**
  * @author Petter Holmström (petter@vaadin.com)
@@ -41,20 +43,28 @@ public class VaadinAutoConfiguration {
     @EnableVaadin
     @Import(StaticContentVaadinServletConfiguration.class)
     static class EnableVaadinConfiguration implements InitializingBean {
-        @Override
+        
+    	@Override
         public void afterPropertiesSet() throws Exception {
             logger.debug("{} initialized", getClass().getName());
         }
+    	
     }
 
     @Configuration
     @EnableVaadinServlet
     @ConditionalOnMissingClass(name = "org.vaadin.spring.touchkit.TouchKitUI")
     static class EnableVaadinServletConfiguration implements InitializingBean {
-        @Override
+        
+    	@Override
         public void afterPropertiesSet() throws Exception {
             logger.debug("{} initialized", getClass().getName());
         }
+    	
     }
 
+    @Bean
+    VaadinApplicationContext vaadinApplicationContext() {
+    	return new VaadinApplicationContext();
+    }
 }

--- a/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/context/VaadinApplicationContext.java
+++ b/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/context/VaadinApplicationContext.java
@@ -1,0 +1,37 @@
+package org.vaadin.spring.boot.context;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.Assert;
+import org.vaadin.spring.boot.VaadinAutoConfiguration;
+import org.vaadin.spring.events.EventBus;
+
+public class VaadinApplicationContext implements ApplicationContextAware, InitializingBean {
+
+	private static Logger logger = LoggerFactory.getLogger(VaadinAutoConfiguration.class);
+	
+	private static ApplicationContext context;
+	
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		context = applicationContext;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(context, "Failed to autowire <ApplicationContext>");
+		logger.debug("{} initialized", getClass().getName());	
+	}
+
+	public static ApplicationContext getContext() {
+		return context;
+	}
+
+	public static EventBus getEventBus() {
+		return context.getBean(EventBus.class);
+	}
+}


### PR DESCRIPTION
Added VaadinApplicationContext
Added VaadinApplicationContext as bean to autoconfiguration.

VaadinApplicationContext Allows to use the Spring application context as static from anywhere within the application.

Example usage:
EventBus eventBus = VaadinApplicationContext.getEventBus();

Reason for adding to vaadin-spring-boot:
Allows access to eventbus and applicationContext from NON-Managed Spring Beans.

Within the future VaadinApplicationContext can be extended with more helpful methods.
