### PR TITLE
ViewProviderAccessDelegate uses AccessDecisionManager if available

### DIFF
--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/Security.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/Security.java
@@ -252,4 +252,14 @@ public class Security {
         }
         return false;
     }
+    
+    /** 
+     * Checks if the Security bean has an accessDecisionManager
+     * 
+     * @return true if the Security bean has an accessDecisionManager
+     */
+    public boolean hasAccessDecisionManager()
+    {
+    	return (accessDecisionManager != null);
+    }
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/SpringSecurityViewProviderAccessDelegate.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/SpringSecurityViewProviderAccessDelegate.java
@@ -44,9 +44,15 @@ public class SpringSecurityViewProviderAccessDelegate implements SpringViewProvi
 
     @Override
     public boolean isAccessGranted(String beanName, UI ui) {
+    	
     	Object securedObject = applicationContext.getBean(beanName);
         Secured viewSecured = applicationContext.findAnnotationOnBean(beanName, Secured.class);
         
-        return !(viewSecured != null && !security.hasAccessToSecuredObject(securedObject));
+        if ( viewSecured == null )
+        	return true;
+        else if ( security.hasAccessDecisionManager() )
+        	return security.hasAccessToSecuredObject(securedObject);
+        else
+        	return security.hasAnyAuthority(viewSecured.value());
     }
 }


### PR DESCRIPTION
If an AccessDecisionManager is available for the Security Bean the standard ViewProviderAccessDelegate will use hasAccessToSecuredObject(). Only if not it will use hasAnyAuthority().
