### PR TITLE
Security update

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ The side bar can be used as a main menu in applications with many views. It is i
 More information can be found [here](spring-vaadin-sidebar/README.md)
 
 ## Security Support ##
-
-The Spring Security integration is still in very early stages of development. Do not assume it will work, and don't use
-it in your projects until the supported features are listed in this README.
+#### Experimental ####
+The Spring Security integration is still in very early stages of development. Do not assume it will work.
+More Information can be found [here](spring-vaadin-security/README.md)
 
 ## Testing
 

--- a/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/BannerPresenter.java
+++ b/samples/mvp-sample/src/main/java/org/vaadin/spring/samples/mvp/ui/presenter/BannerPresenter.java
@@ -8,13 +8,13 @@ import org.vaadin.spring.events.EventBusListenerMethod;
 import org.vaadin.spring.navigator.Presenter;
 import org.vaadin.spring.navigator.VaadinPresenter;
 import org.vaadin.spring.samples.mvp.ui.view.BannerView;
-import org.vaadin.spring.security.Security;
+import org.vaadin.spring.security.VaadinSecurity;
 
 @VaadinPresenter(viewName = BannerView.NAME)
 public class BannerPresenter extends Presenter<BannerView> {
 
 	@Inject
-	Security security;
+	VaadinSecurity security;
 
 	@EventBusListenerMethod(filter=StartupFilter.class)
 	public void onStartup(Action action) {

--- a/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/VaadinSecurityAutoConfiguration.java
+++ b/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/VaadinSecurityAutoConfiguration.java
@@ -20,12 +20,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
-import org.vaadin.spring.security.EnableVaadinSecurity;
 import org.vaadin.spring.security.Security;
+import org.vaadin.spring.security.annotation.EnableVaadinSecurity;
 
 /**
  * @author Petter Holmström (petter@vaadin.com)
- * @see org.vaadin.spring.security.EnableVaadinSecurity
+ * @see org.vaadin.spring.security.annotation.EnableVaadinSecurity
  */
 @Configuration
 @ConditionalOnClass(Security.class)

--- a/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/VaadinSecurityAutoConfiguration.java
+++ b/spring-boot-vaadin/src/main/java/org/vaadin/spring/boot/VaadinSecurityAutoConfiguration.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Configuration;
-import org.vaadin.spring.security.Security;
+import org.vaadin.spring.security.VaadinSecurity;
 import org.vaadin.spring.security.annotation.EnableVaadinSecurity;
 
 /**
@@ -28,7 +28,7 @@ import org.vaadin.spring.security.annotation.EnableVaadinSecurity;
  * @see org.vaadin.spring.security.annotation.EnableVaadinSecurity
  */
 @Configuration
-@ConditionalOnClass(Security.class)
+@ConditionalOnClass(VaadinSecurity.class)
 public class VaadinSecurityAutoConfiguration {
 
     private static Logger logger = LoggerFactory.getLogger(VaadinSecurityAutoConfiguration.class);

--- a/spring-vaadin-security/README.md
+++ b/spring-vaadin-security/README.md
@@ -8,7 +8,7 @@ Spring security for a Vaadin application can be enabled by the annotation ```@En
 <br><br>
 Because ```@PreAuthorize``` annotations are enabled a default ```AccessDecisionManager``` is created.
 
-### Override ```AccessDecisionManager``` ###
+#### Override ```AccessDecisionManager``` ####
 A custom ```AccessDecisionManager``` can be implemented by defining a AccessDecisionManager with either the id of ```VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER``` or by providing your custom AccessDecisionManager with the annotation ```@Bean(name = VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER```
 
 ## VaadinSecurityContext ###

--- a/spring-vaadin-security/README.md
+++ b/spring-vaadin-security/README.md
@@ -9,7 +9,7 @@ Spring security for a Vaadin application can be enabled by the annotation ```@En
 Because ```@PreAuthorize``` annotations are enabled a default ```AccessDecisionManager``` is created.
 
 #### Override ```AccessDecisionManager``` ####
-A custom ```AccessDecisionManager``` can be implemented by defining a AccessDecisionManager with either the id of ```VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER``` or by providing your custom AccessDecisionManager with the annotation ```@Bean(name = VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER```
+A custom ```AccessDecisionManager``` can be implemented by defining a AccessDecisionManager with either the id of ```VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER``` or by providing your custom AccessDecisionManager with the annotation ```@Bean(name = VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER)```
 
 ## VaadinSecurityContext ###
 The VaadinSecurityContext interface provides access to common spring security objects.

--- a/spring-vaadin-security/README.md
+++ b/spring-vaadin-security/README.md
@@ -1,0 +1,96 @@
+Vaadin4Spring Security
+==========================
+
+# Implementation Notice
+This artifact is considerd experimental.
+
+## General ##
+Spring security for a Vaadin application can be enabled by the annotation ```@EnableVaadinSecurity```.
+<br><br>
+```GlobalMethodSecurity``` is enabled by default, for ```@Secured``` annotations and ```@PreAuthorize``` annotations. ```@PostAuthorize``` is currently not supported.
+<br><br>
+Because ```@PreAuthorize``` annotations are enabled a default ```AccessDecisionManager``` is created.
+
+### Override ```AccessDecisionManager``` ###
+A custom ```AccessDecisionManager``` can be implemented by defining a AccessDecisionManager with either the id of ```VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER``` or by providing your custom AccessDecisionManager with the annotation ```@Bean(name = VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER```
+
+## VaadinSecurityContext ###
+The VaadinSecurityContext interface provides access to common spring security objects.
+
+- ```ApplicationContext```
+- ```AuthenticationManager```
+- ```AccessDecisionManager```
+
+#### Methods ####
+
+- ```ApplicationContext getApplicationContext();```
+- ```AuthenticationManager getAuthenticationManager();```
+- ```AccessDecisionManager getAccessDecisionManager();```
+- ```boolean hasAccessDecisionManager();```
+
+#### Usage ####
+The ```VaadinSecurityContext``` can be used by either use of ```@Autowired```. Or by the use of the ```VaadinSecurityContextAware``` interface. This works the same like the Spring ```ApplicationContextAware``` interface.
+
+Example Autowired
+```java
+@Autowired
+VaadinSecurityContext vaadinSecurityContext;
+...
+```
+
+Example VaadinSecurityContextAware
+```java
+public class Dummy implements VaadinSecurityContextAware {
+
+    private VaadinSecurityContext vaadinSecurityContext;
+
+    @Override
+    public void setVaadinSecurityContext(VaadinSecurityContext vaadinSecurityContext) {
+        this.vaadinSecurityContext = vaadinSecurityContext;
+    }
+
+...
+}
+```
+
+## VaadinSecurity ##
+The VaadinSecurity interface provides access to commonly required Spring Security operations in a Vaadin application. It also extends ```VaadinSecurityContext```.
+
+#### Methods ####
+
+-  ```boolean isAuthenticated();```
+-  ```void login(Authentication authentication) throws AuthenticationException;```
+-  ```void login(String username, String password) throws AuthenticationException;```
+-  ```void logout();```
+-  ```boolean hasAuthority(String authority);```
+-  ```Authentication getAuthentication();```
+-  ```boolean hasAccessToObject(Object securedObject, String... securityConfigurationAttributes);```
+-  ```boolean hasAccessToSecuredObject(Object securedObject);```
+-  ```boolean hasAccessToSecuredMethod(Object securedObject, String methodName, Class<?>... methodParameterTypes);```
+-  ```boolean hasAuthorities(String... authorities);```
+-  ```boolean hasAnyAuthority(String... authorities);```
+
+#### Usage ####
+```VaadinSecurity``` can be used by either use of ```@Autowired```. Or by the use of the ```VaadinSecurityAware``` interface. This works the same like the Spring ```ApplicationContextAware``` interface.
+
+Example Autowired
+```java
+@Autowired
+VaadinSecurity vaadinSecurity;
+...
+```
+
+Example VaadinSecurityAware
+```java
+public class Dummy implements VaadinSecurityAware {
+
+    private VaadinSecurity vaadinSecurity;
+
+    @Override
+    public void setVaadinSecurity(VaadinSecurity vaadinSecurity) {
+        this.vaadinSecurity = vaadinSecurity;
+    }
+
+...
+}
+```

--- a/spring-vaadin-security/README.md
+++ b/spring-vaadin-security/README.md
@@ -67,6 +67,12 @@ The VaadinSecurity interface provides access to commonly required Spring Securit
 -  ```boolean hasAuthorities(String... authorities);```
 -  ```boolean hasAnyAuthority(String... authorities);```
 
+##### Methods Inherited from VaadinSecurityContext #####
+- ```ApplicationContext getApplicationContext();```
+- ```AuthenticationManager getAuthenticationManager();```
+- ```AccessDecisionManager getAccessDecisionManager();```
+- ```boolean hasAccessDecisionManager();```
+
 #### Usage ####
 ```VaadinSecurity``` can be used by either use of ```@Autowired```. Or by the use of the ```VaadinSecurityAware``` interface. This works the same like the Spring ```ApplicationContextAware``` interface.
 

--- a/spring-vaadin-security/README.md
+++ b/spring-vaadin-security/README.md
@@ -1,9 +1,6 @@
-Vaadin4Spring Security
+Vaadin4Spring Security (Experimental)
 ==========================
-
-# Implementation Notice
-This artifact is considerd experimental.
-
+<br>
 ## General ##
 Spring security for a Vaadin application can be enabled by the annotation ```@EnableVaadinSecurity```.
 <br><br>

--- a/spring-vaadin-security/pom.xml
+++ b/spring-vaadin-security/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parent-pom</artifactId>
         <groupId>org.vaadin.spring</groupId>
@@ -27,6 +26,28 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>spring-vaadin</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.vaadin.spring</groupId>
+            <artifactId>spring-vaadin-test</artifactId>
+            <version>0.0.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/spring-vaadin-security/pom.xml
+++ b/spring-vaadin-security/pom.xml
@@ -30,25 +30,57 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.vaadin.spring</groupId>
-            <artifactId>spring-vaadin-test</artifactId>
-            <version>0.0.4-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-vaadin-test</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-expression</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.inject</groupId>
+			<artifactId>javax.inject</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-vaadin-security/pom.xml
+++ b/spring-vaadin-security/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>spring-security-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>spring-vaadin</artifactId>
             <version>${project.version}</version>

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security;
 
 import org.slf4j.Logger;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
@@ -20,18 +20,18 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractVaadinSecurity implements ApplicationContextAware, InitializingBean, VaadinSecurityContext {
 
-	private final Logger logger = LoggerFactory.getLogger(getClass());
-	
-	private ApplicationContext applicationContext;
-	private AuthenticationManager authenticationManager;
-	private AccessDecisionManager accessDecisionManager;
-	
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(applicationContext, "Failed to Autowire <ApplicationContext>");
-		
-		AuthenticationManager authenticationManager;
-    	try {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private ApplicationContext applicationContext;
+    private AuthenticationManager authenticationManager;
+    private AccessDecisionManager accessDecisionManager;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull(applicationContext, "Failed to Autowire <ApplicationContext>");
+
+        AuthenticationManager authenticationManager;
+        try {
             authenticationManager = applicationContext.getBean(AuthenticationManager.class);
         } catch (NoSuchBeanDefinitionException ex) {
             authenticationManager = null;
@@ -45,47 +45,47 @@ public abstract class AbstractVaadinSecurity implements ApplicationContextAware,
             accessDecisionManager = null;
             logger.warn("No AccessDecisionManager set! Some security methods will not be available.");
         }
-        
+
         this.authenticationManager = authenticationManager;
         this.accessDecisionManager = accessDecisionManager;
-	}
+    }
 
-	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		this.applicationContext = applicationContext;
-	}
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public ApplicationContext getApplicationContext() {
-		return applicationContext;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public AuthenticationManager getAuthenticationManager() {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AuthenticationManager getAuthenticationManager() {
         if (authenticationManager == null) {
             throw new IllegalStateException("No AuthenticationManager has been set");
         }
         return authenticationManager;
     }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public AccessDecisionManager getAccessDecisionManager() {
-		return accessDecisionManager;
-	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AccessDecisionManager getAccessDecisionManager() {
+        return accessDecisionManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public boolean hasAccessDecisionManager() {
-       return (accessDecisionManager != null);
+        return (accessDecisionManager != null);
     }
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
@@ -1,0 +1,91 @@
+package org.vaadin.spring.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.security.access.AccessDecisionManager;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.util.Assert;
+
+/**
+ * Abstract implementation for the {@link org.vaadin.spring.security.VaadinSecurity}
+ * 
+ * @author Petter Holmström (petter@vaadin.com)
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ *
+ */
+public abstract class AbstractVaadinSecurity implements ApplicationContextAware, InitializingBean, VaadinSecurityContext {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+	
+	private ApplicationContext applicationContext;
+	private AuthenticationManager authenticationManager;
+	private AccessDecisionManager accessDecisionManager;
+	
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(applicationContext, "Failed to Autowire <ApplicationContext>");
+		
+		AuthenticationManager authenticationManager;
+    	try {
+            authenticationManager = applicationContext.getBean(AuthenticationManager.class);
+        } catch (NoSuchBeanDefinitionException ex) {
+            authenticationManager = null;
+            logger.warn("No AuthenticationManager set! Some security methods will not be available.");
+        }
+
+        AccessDecisionManager accessDecisionManager;
+        try {
+            accessDecisionManager = applicationContext.getBean(AccessDecisionManager.class);
+        } catch (NoSuchBeanDefinitionException ex) {
+            accessDecisionManager = null;
+            logger.warn("No AccessDecisionManager set! Some security methods will not be available.");
+        }
+        
+        this.authenticationManager = authenticationManager;
+        this.accessDecisionManager = accessDecisionManager;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ApplicationContext getApplicationContext() {
+		return applicationContext;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AuthenticationManager getAuthenticationManager() {
+        if (authenticationManager == null) {
+            throw new IllegalStateException("No AuthenticationManager has been set");
+        }
+        return authenticationManager;
+    }
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AccessDecisionManager getAccessDecisionManager() {
+		return accessDecisionManager;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+    public boolean hasAccessDecisionManager() {
+       return (accessDecisionManager != null);
+    }
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/GenericVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/GenericVaadinSecurity.java
@@ -91,13 +91,13 @@ public class GenericVaadinSecurity extends AbstractVaadinSecurity implements Vaa
         if (authentication == null || !authentication.isAuthenticated()) {
             return false;
         }
-        
+
         for (GrantedAuthority grantedAuthority : authentication.getAuthorities()) {
             if (authority.equals(grantedAuthority.getAuthority())) {
                 return true;
             }
         }
-        
+
         return false;
     }
 
@@ -123,12 +123,12 @@ public class GenericVaadinSecurity extends AbstractVaadinSecurity implements Vaa
             }
             return false;
         }
-        
+
         final Collection<ConfigAttribute> configAttributes = new ArrayList<ConfigAttribute>(securityConfigurationAttributes.length);
         for (String securityConfigString : securityConfigurationAttributes) {
             configAttributes.add(new SecurityConfig(securityConfigString));
         }
-        
+
         try {
             getAccessDecisionManager().decide(authentication, securedObject, configAttributes);
             return true;
@@ -154,7 +154,7 @@ public class GenericVaadinSecurity extends AbstractVaadinSecurity implements Vaa
      */
     @Override
     public boolean hasAccessToSecuredMethod(Object securedObject, String methodName, Class<?>... methodParameterTypes) {
-        
+
         try {
             final Method method = securedObject.getClass().getMethod(methodName, methodParameterTypes);
             final Secured secured = AnnotationUtils.findAnnotation(method, Secured.class);
@@ -163,7 +163,7 @@ public class GenericVaadinSecurity extends AbstractVaadinSecurity implements Vaa
         } catch (NoSuchMethodException ex) {
             throw new IllegalArgumentException("Method " + methodName + " does not exist", ex);
         }
-        
+
     }
 
     /**
@@ -171,13 +171,13 @@ public class GenericVaadinSecurity extends AbstractVaadinSecurity implements Vaa
      */
     @Override
     public boolean hasAuthorities(String... authorities) {
-        
+
         for (String authority : authorities) {
             if (!hasAuthority(authority)) {
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -186,13 +186,13 @@ public class GenericVaadinSecurity extends AbstractVaadinSecurity implements Vaa
      */
     @Override
     public boolean hasAnyAuthority(String... authorities) {
-        
+
         for (String authority : authorities) {
             if (hasAuthority(authority)) {
                 return true;
             }
         }
-        
+
         return false;
     }
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/GenericVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/GenericVaadinSecurity.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.vaadin.spring.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.Assert;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Convenience class that provides the Spring Security operations that are most commonly required in a Vaadin application.
+ *
+ * @author Petter Holmström (petter@vaadin.com)
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ */
+public class GenericVaadinSecurity extends AbstractVaadinSecurity implements VaadinSecurity {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAuthenticated() {
+        final Authentication authentication = getAuthentication();
+        return ( authentication != null && authentication.isAuthenticated() );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void login(Authentication authentication) throws AuthenticationException {
+        final Authentication fullyAuthenticated = getAuthenticationManager().authenticate(authentication);
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(fullyAuthenticated);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void login(String username, String password) throws AuthenticationException {
+        login(new UsernamePasswordAuthenticationToken(username, password));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void logout() {
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasAuthority(String authority) {
+        final Authentication authentication = getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        
+        for (GrantedAuthority grantedAuthority : authentication.getAuthorities()) {
+            if (authority.equals(grantedAuthority.getAuthority())) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Authentication getAuthentication() {
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
+        final Authentication authentication = securityContext.getAuthentication();
+        return authentication;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasAccessToObject(Object securedObject, String... securityConfigurationAttributes) {
+        final Authentication authentication = getAuthentication();
+        if (getAccessDecisionManager() == null || authentication == null || !authentication.isAuthenticated()) {
+            if (getAccessDecisionManager() == null) {
+                logger.warn("Access was denied to object because there was no AccessDecisionManager set!");
+            }
+            return false;
+        }
+        
+        final Collection<ConfigAttribute> configAttributes = new ArrayList<ConfigAttribute>(securityConfigurationAttributes.length);
+        for (String securityConfigString : securityConfigurationAttributes) {
+            configAttributes.add(new SecurityConfig(securityConfigString));
+        }
+        
+        try {
+            getAccessDecisionManager().decide(authentication, securedObject, configAttributes);
+            return true;
+        } catch (AccessDeniedException ex) {
+            return false;
+        } catch (InsufficientAuthenticationException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasAccessToSecuredObject(Object securedObject) {
+        final Secured secured = AopUtils.getTargetClass(securedObject).getAnnotation(Secured.class);
+        Assert.notNull(secured, "securedObject did not have @Secured annotation");
+        return hasAccessToObject(securedObject, secured.value());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasAccessToSecuredMethod(Object securedObject, String methodName, Class<?>... methodParameterTypes) {
+        
+        try {
+            final Method method = securedObject.getClass().getMethod(methodName, methodParameterTypes);
+            final Secured secured = AnnotationUtils.findAnnotation(method, Secured.class);
+            Assert.notNull(secured, "securedObject did not have @Secured annotation");
+            return hasAccessToObject(securedObject, secured.value());
+        } catch (NoSuchMethodException ex) {
+            throw new IllegalArgumentException("Method " + methodName + " does not exist", ex);
+        }
+        
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasAuthorities(String... authorities) {
+        
+        for (String authority : authorities) {
+            if (!hasAuthority(authority)) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasAnyAuthority(String... authorities) {
+        
+        for (String authority : authorities) {
+            if (hasAuthority(authority)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/SpringSecurityViewProviderAccessDelegate.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/SpringSecurityViewProviderAccessDelegate.java
@@ -26,19 +26,19 @@ import org.vaadin.spring.navigator.SpringViewProvider;
 /**
  * Implementation of {@link org.vaadin.spring.navigator.SpringViewProvider.ViewProviderAccessDelegate} that
  * checks if a view has the {@link org.springframework.security.access.annotation.Secured} annotation and if so,
- * uses the {@link org.vaadin.spring.security.Security} instance to check if the current user is authorized to
+ * uses the {@link org.vaadin.spring.security.VaadinSecurity} instance to check if the current user is authorized to
  * access the view.
  *
  * @author Petter Holmström (petter@vaadin.com)
- * @see Security#hasAnyAuthority(String...)
+ * @see VaadinSecurity#hasAnyAuthority(String...)
  */
 public class SpringSecurityViewProviderAccessDelegate implements SpringViewProvider.ViewProviderAccessDelegate {
 
-    private final Security security;
+    private final VaadinSecurity security;
     private final ApplicationContext applicationContext;
 
     @Autowired
-    public SpringSecurityViewProviderAccessDelegate(Security security, ApplicationContext applicationContext) {
+    public SpringSecurityViewProviderAccessDelegate(VaadinSecurity security, ApplicationContext applicationContext) {
         this.security = security;
         this.applicationContext = applicationContext;
     }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
@@ -45,7 +45,7 @@ import java.util.Collection;
  *
  * @author Petter Holmström (petter@vaadin.com)
  */
-public class Security {
+public class VaadinSecurity {
 
     private final AuthenticationManager authenticationManager;
 
@@ -56,7 +56,7 @@ public class Security {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired(required = false)
-    public Security(AuthenticationManager authenticationManager, AccessDecisionManager accessDecisionManager, ApplicationContext applicationContext) {
+    public VaadinSecurity(AuthenticationManager authenticationManager, AccessDecisionManager accessDecisionManager, ApplicationContext applicationContext) {
         this.authenticationManager = authenticationManager;
         if (authenticationManager == null) {
             logger.warn("No AuthenticationManager set! Some security methods will not be available.");

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security;
 
 import org.springframework.security.core.Authentication;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
@@ -56,7 +56,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @see org.springframework.security.core.Authentication#getAuthorities()
      * @see org.springframework.security.core.GrantedAuthority#getAuthority()
      */
-    public boolean hasAuthority(String authority);
+    boolean hasAuthority(String authority);
 
     /**
      * Gets the authentication token of the current user.

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
@@ -12,7 +12,7 @@ import org.springframework.security.core.AuthenticationException;
  */
 public interface VaadinSecurity extends VaadinSecurityContext {
 
-	/**
+    /**
      * Checks if the current user is authenticated.
      *
      * @return true if the current {@link org.springframework.security.core.context.SecurityContext} contains an {@link org.springframework.security.core.Authentication} token,
@@ -20,7 +20,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @see org.springframework.security.core.Authentication#isAuthenticated()
      */
     boolean isAuthenticated();
-	
+
     /**
      * Tries to login using the specified authentication object. If authentication succeeds, this method
      * will return without exceptions.
@@ -29,7 +29,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @throws org.springframework.security.core.AuthenticationException if authentication fails.
      */
     void login(Authentication authentication) throws AuthenticationException;
-    
+
     /**
      * Convenience method that invokes {@link #login(org.springframework.security.core.Authentication)} with a
      * {@link org.springframework.security.authentication.UsernamePasswordAuthenticationToken}-object.
@@ -39,13 +39,13 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @throws AuthenticationException if authentication fails.
      */
     void login(String username, String password) throws AuthenticationException;
-    
+
     /**
      * Logs the user out, clearing the {@link org.springframework.security.core.context.SecurityContext} without
      * invalidating the session.
      */
     void logout();
-    
+
     /**
      * Checks if the current user has the specified authority. This method works with static authorities (such as roles).
      * If you need more dynamic authorization (such as ACLs or EL expressions), use {@link #hasAccessToObject(Object, String...)}.
@@ -57,14 +57,14 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @see org.springframework.security.core.GrantedAuthority#getAuthority()
      */
     public boolean hasAuthority(String authority);
-    
+
     /**
      * Gets the authentication token of the current user.
      *
      * @return the {@link org.springframework.security.core.Authentication} token stored in the current {@link org.springframework.security.core.context.SecurityContext}, or {@code null}.
      */
     Authentication getAuthentication();
-    
+
     /**
      * Checks if the current user is authorized based on the specified security configuration attributes. The attributes
      * can be roles or Spring EL expressions (basically anything you can specify as values of the {@link org.springframework.security.access.annotation.Secured} annotation).
@@ -74,7 +74,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @return true if the current user is authorized, false if not.
      */
     boolean hasAccessToObject(Object securedObject, String... securityConfigurationAttributes);
-    
+
     /**
      * Convenience method that invokes {@link #hasAccessToObject(Object, String...)}, using the {@link org.springframework.security.access.annotation.Secured} annotation of the secured object
      * to get the security configuration attributes.
@@ -83,7 +83,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @return true if the current user is authorized, false if not.
      */
     boolean hasAccessToSecuredObject(Object securedObject);
-    
+
     /**
      * Uses the {@link org.springframework.security.access.annotation.Secured} annotation on the specified method to check if the current user has access to the secured object.
      *
@@ -94,7 +94,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @see #hasAccessToSecuredObject(Object)
      */
     boolean hasAccessToSecuredMethod(Object securedObject, String methodName, Class<?>... methodParameterTypes);
-    
+
     /**
      * Checks if the current user has all required authorities.
      *
@@ -104,7 +104,7 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @see #hasAnyAuthority(String...)
      */
     boolean hasAuthorities(String... authorities);
-    
+
     /**
      * Checks if the current user has at least one of the specified authorities.
      *
@@ -114,5 +114,5 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      * @see #hasAuthorities(String...)
      */
     boolean hasAnyAuthority(String... authorities);
-    
+
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityAware.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security;
 
 import org.springframework.beans.factory.Aware;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityAware.java
@@ -11,13 +11,13 @@ import org.springframework.beans.factory.Aware;
  */
 public interface VaadinSecurityAware extends Aware {
 
-	/**
-	 * Set the VaadinSecurity.
-	 * <p>Invoked after population of normal bean properties but before an init callback such
-	 * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
-	 * or a custom init-method.
-	 * 
-	 * @param vaadinSecurity the VaadinSecurity object used within the applicationContext.
-	 */
-	void setVaadinSecurity(VaadinSecurity vaadinSecurity);
+    /**
+     * Set the VaadinSecurity.
+     * <p>Invoked after population of normal bean properties but before an init callback such
+     * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
+     * or a custom init-method.
+     * 
+     * @param vaadinSecurity the VaadinSecurity object used within the applicationContext.
+     */
+    void setVaadinSecurity(VaadinSecurity vaadinSecurity);
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityAware.java
@@ -1,0 +1,23 @@
+package org.vaadin.spring.security;
+
+import org.springframework.beans.factory.Aware;
+
+/**
+ * Interface to be implemented by any object that wishes to be notified 
+ * of the {@link org.vaadin.spring.security.VaadinSecurity}.
+ *  
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ *
+ */
+public interface VaadinSecurityAware extends Aware {
+
+	/**
+	 * Set the VaadinSecurity.
+	 * <p>Invoked after population of normal bean properties but before an init callback such
+	 * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
+	 * or a custom init-method.
+	 * 
+	 * @param vaadinSecurity the VaadinSecurity object used within the applicationContext.
+	 */
+	void setVaadinSecurity(VaadinSecurity vaadinSecurity);
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
@@ -1,0 +1,44 @@
+package org.vaadin.spring.security;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.access.AccessDecisionManager;
+import org.springframework.security.authentication.AuthenticationManager;
+
+/**
+ * Interface which provides access to basic Security Context objects.
+ * 
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ *
+ */
+public interface VaadinSecurityContext {
+
+	/**
+	 * Get the current Spring ApplicationContext
+	 * 
+	 * @return {@link org.springframework.context.ApplicationContext}
+	 */
+	ApplicationContext getApplicationContext();
+	
+	/**
+	 * Get the configured {@link org.springframework.security.authentication.AuthenticationManager}
+	 * return {@code null} if not available.
+	 * 
+	 * @return {@link org.springframework.security.authentication.AuthenticationManager}
+	 */
+	AuthenticationManager getAuthenticationManager();
+	
+	/**
+	 * Get the configured {@link org.springframework.security.access.AccessDecisionManager}
+	 * return {@code null} if not available.
+	 * 
+	 * @return {@link org.springframework.security.access.AccessDecisionManager}
+	 */
+	AccessDecisionManager getAccessDecisionManager();
+	
+	/** 
+     * Checks if the Security bean has an accessDecisionManager
+     * 
+     * @return true if the Security bean has an accessDecisionManager
+     */
+	boolean hasAccessDecisionManager();
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security;
 
 import org.springframework.context.ApplicationContext;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
@@ -12,33 +12,33 @@ import org.springframework.security.authentication.AuthenticationManager;
  */
 public interface VaadinSecurityContext {
 
-	/**
-	 * Get the current Spring ApplicationContext
-	 * 
-	 * @return {@link org.springframework.context.ApplicationContext}
-	 */
-	ApplicationContext getApplicationContext();
-	
-	/**
-	 * Get the configured {@link org.springframework.security.authentication.AuthenticationManager}
-	 * return {@code null} if not available.
-	 * 
-	 * @return {@link org.springframework.security.authentication.AuthenticationManager}
-	 */
-	AuthenticationManager getAuthenticationManager();
-	
-	/**
-	 * Get the configured {@link org.springframework.security.access.AccessDecisionManager}
-	 * return {@code null} if not available.
-	 * 
-	 * @return {@link org.springframework.security.access.AccessDecisionManager}
-	 */
-	AccessDecisionManager getAccessDecisionManager();
-	
-	/** 
+    /**
+     * Get the current Spring ApplicationContext
+     * 
+     * @return {@link org.springframework.context.ApplicationContext}
+     */
+    ApplicationContext getApplicationContext();
+
+    /**
+     * Get the configured {@link org.springframework.security.authentication.AuthenticationManager}
+     * return {@code null} if not available.
+     * 
+     * @return {@link org.springframework.security.authentication.AuthenticationManager}
+     */
+    AuthenticationManager getAuthenticationManager();
+
+    /**
+     * Get the configured {@link org.springframework.security.access.AccessDecisionManager}
+     * return {@code null} if not available.
+     * 
+     * @return {@link org.springframework.security.access.AccessDecisionManager}
+     */
+    AccessDecisionManager getAccessDecisionManager();
+
+    /** 
      * Checks if the Security bean has an accessDecisionManager
      * 
      * @return true if the Security bean has an accessDecisionManager
      */
-	boolean hasAccessDecisionManager();
+    boolean hasAccessDecisionManager();
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
@@ -1,0 +1,22 @@
+package org.vaadin.spring.security;
+
+/**
+ * Interface to be implemented by any object that wishes to be notified
+ * of the {@link org.vaadin.spring.security.VaadinSecurityContext}.
+ * 
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ *
+ */
+public interface VaadinSecurityContextAware {
+
+	/**
+	 * Set the VaadinSecurityContext.
+	 * <p>Invoked after population of normal bean properties but before an init callback such
+	 * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
+	 * or a custom init-method.
+	 * 
+	 * @param vaadinSecurityContext the VaadinSecurityContext object.
+	 */
+	void setVaadinSecurityContext(VaadinSecurityContext vaadinSecurityContext);
+	
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
@@ -9,14 +9,14 @@ package org.vaadin.spring.security;
  */
 public interface VaadinSecurityContextAware {
 
-	/**
-	 * Set the VaadinSecurityContext.
-	 * <p>Invoked after population of normal bean properties but before an init callback such
-	 * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
-	 * or a custom init-method.
-	 * 
-	 * @param vaadinSecurityContext the VaadinSecurityContext object.
-	 */
-	void setVaadinSecurityContext(VaadinSecurityContext vaadinSecurityContext);
-	
+    /**
+     * Set the VaadinSecurityContext.
+     * <p>Invoked after population of normal bean properties but before an init callback such
+     * as {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}
+     * or a custom init-method.
+     * 
+     * @param vaadinSecurityContext the VaadinSecurityContext object.
+     */
+    void setVaadinSecurityContext(VaadinSecurityContext vaadinSecurityContext);
+
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security;
 
 import org.springframework.beans.factory.Aware;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContextAware.java
@@ -1,5 +1,7 @@
 package org.vaadin.spring.security;
 
+import org.springframework.beans.factory.Aware;
+
 /**
  * Interface to be implemented by any object that wishes to be notified
  * of the {@link org.vaadin.spring.security.VaadinSecurityContext}.
@@ -7,7 +9,7 @@ package org.vaadin.spring.security;
  * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
  *
  */
-public interface VaadinSecurityContextAware {
+public interface VaadinSecurityContextAware extends Aware {
 
     /**
      * Set the VaadinSecurityContext.

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/annotation/EnableVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/annotation/EnableVaadinSecurity.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.vaadin.spring.security;
+package org.vaadin.spring.security.annotation;
 
 import org.springframework.context.annotation.Import;
 import org.vaadin.spring.security.config.VaadinSecurityConfiguration;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.vaadin.spring.security.Security;
+import org.vaadin.spring.security.VaadinSecurity;
 import org.vaadin.spring.security.SpringSecurityViewProviderAccessDelegate;
 
 /**
@@ -60,7 +60,7 @@ public class VaadinSecurityConfiguration implements ApplicationContextAware {
     }
 
     @Bean
-    Security security() {
+    VaadinSecurity security() {
         AuthenticationManager authenticationManager;
         try {
             authenticationManager = applicationContext.getBean(AuthenticationManager.class);
@@ -74,7 +74,7 @@ public class VaadinSecurityConfiguration implements ApplicationContextAware {
         } catch (NoSuchBeanDefinitionException ex) {
             accessDecisionManager = null;
         }
-        return new Security(authenticationManager, accessDecisionManager, applicationContext);
+        return new VaadinSecurity(authenticationManager, accessDecisionManager, applicationContext);
     }
 
     @Bean

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.vaadin.spring.security.GenericVaadinSecurity;
 import org.vaadin.spring.security.VaadinSecurity;
-import org.vaadin.spring.security.provider.SpringSecurityViewProviderAccessDelegate;
+import org.vaadin.spring.security.provider.SecuredViewProviderAccessDelegate;
 import org.vaadin.spring.security.support.VaadinSecurityAwareProcessor;
 
 /**
@@ -82,8 +82,8 @@ public class VaadinSecurityConfiguration {
     }
 
     @Bean
-    SpringSecurityViewProviderAccessDelegate viewProviderAccessDelegate() {
-        return new SpringSecurityViewProviderAccessDelegate();
+    SecuredViewProviderAccessDelegate viewProviderAccessDelegate() {
+        return new SecuredViewProviderAccessDelegate();
     }
 
     /**

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
@@ -41,22 +41,22 @@ import org.vaadin.spring.security.support.VaadinSecurityAwareProcessor;
  */
 @Configuration
 public class VaadinSecurityConfiguration {
-    
+
     public static final class Beans {
-        
+
         public static final String VAADIN_SECURITY                  = "vaadinSecurity";
         public static final String VAADIN_SECURITY_AWARE_PROCESSOR  = "vaadinSecurityProcessor";
         public static final String CURRENT_USER                     = "currentUser";
         public static final String ACCESS_DECISION_MANAGER          = "accessDecisionManager";
         public static final String AUTHENTICATION_MANAGER           = "authenticationManager";
-        
+
     }
-    
+
     @Bean(name = Beans.CURRENT_USER)
     Authentication currentUser() {
-        
+
         return ProxyFactory.getProxy(Authentication.class, new MethodInterceptor() {
-            
+
             @Override
             public Object invoke(MethodInvocation invocation) throws Throwable {
                 SecurityContext securityContext = SecurityContextHolder.getContext();
@@ -66,16 +66,16 @@ public class VaadinSecurityConfiguration {
                 }
                 return invocation.getMethod().invoke(authentication, invocation.getArguments());
             }
-            
+
         });
-        
+
     }
 
     @Bean(name = Beans.VAADIN_SECURITY)
     VaadinSecurity vaadinSecurity() {
-       return new GenericVaadinSecurity();
+        return new GenericVaadinSecurity();
     }
-    
+
     @Bean(name = Beans.VAADIN_SECURITY_AWARE_PROCESSOR)
     VaadinSecurityAwareProcessor vaadinSecurityProcessor() {
         return new VaadinSecurityAwareProcessor();
@@ -105,13 +105,13 @@ public class VaadinSecurityConfiguration {
     @Configuration
     @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
     static class GlobalMethodSecurity extends GlobalMethodSecurityConfiguration {
-        
+
         @Bean(name = VaadinSecurityConfiguration.Beans.ACCESS_DECISION_MANAGER)
         @Override
         protected AccessDecisionManager accessDecisionManager() {
             return super.accessDecisionManager();
         }
-        
+
     }
-    
+
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.vaadin.spring.security.GenericVaadinSecurity;
 import org.vaadin.spring.security.VaadinSecurity;
+import org.vaadin.spring.security.provider.PreAuthorizeViewProviderAccessDelegate;
 import org.vaadin.spring.security.provider.SecuredViewProviderAccessDelegate;
 import org.vaadin.spring.security.support.VaadinSecurityAwareProcessor;
 
@@ -82,8 +83,13 @@ public class VaadinSecurityConfiguration {
     }
 
     @Bean
-    SecuredViewProviderAccessDelegate viewProviderAccessDelegate() {
+    SecuredViewProviderAccessDelegate securedViewProviderAccessDelegate() {
         return new SecuredViewProviderAccessDelegate();
+    }
+    
+    @Bean
+    PreAuthorizeViewProviderAccessDelegate preAuthorizeViewProviderAccessDelegate() {
+        return new PreAuthorizeViewProviderAccessDelegate();
     }
 
     /**

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/config/VaadinSecurityConfiguration.java
@@ -37,7 +37,7 @@ import org.vaadin.spring.security.SpringSecurityViewProviderAccessDelegate;
  * Spring configuration for setting up the Spring Security integration.
  *
  * @author Petter Holmström (petter@vaadin.com)
- * @see org.vaadin.spring.security.EnableVaadinSecurity
+ * @see org.vaadin.spring.security.annotation.EnableVaadinSecurity
  */
 @Configuration
 public class VaadinSecurityConfiguration implements ApplicationContextAware {

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/PreAuthorizeViewProviderAccessDelegate.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/PreAuthorizeViewProviderAccessDelegate.java
@@ -1,0 +1,98 @@
+package org.vaadin.spring.security.provider;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.security.access.AccessDecisionManager;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.ExpressionBasedAnnotationAttributeFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.util.MethodInvocationUtils;
+import org.springframework.util.ClassUtils;
+import org.vaadin.spring.navigator.SpringViewProvider.ViewProviderAccessDelegate;
+import org.vaadin.spring.security.VaadinSecurity;
+import org.vaadin.spring.security.VaadinSecurityAware;
+
+import com.vaadin.navigator.View;
+import com.vaadin.ui.UI;
+
+/**
+ * Implementation of {@link org.vaadin.spring.navigator.SpringViewProvider.ViewProviderAccessDelegate} that
+ * checks if a view has the {@link org.springframework.security.access.prepost.PreAuthorize} annotation and if so,
+ * uses the {@link org.vaadin.spring.security.VaadinSecurity} instance to check if the current user is authorized to
+ * access the view.
+ *
+ * @author Marko Radinovic (markoradinovic79@gmail.com)
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ * <br><br>
+ * Initial code:<a href="https://github.com/markoradinovic/Vaadin4Spring-MVP-Sample-SpringSecurity">https://github.com/markoradinovic/Vaadin4Spring-MVP-Sample-SpringSecurity</a>
+ */
+public class PreAuthorizeViewProviderAccessDelegate implements ApplicationContextAware, VaadinSecurityAware, ViewProviderAccessDelegate {
+
+    private VaadinSecurity security;
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void setVaadinSecurity(VaadinSecurity vaadinSecurity) {
+        this.security = vaadinSecurity;
+    }
+
+    @Override
+    public boolean isAccessGranted(String beanName, UI ui) {
+
+        PreAuthorize viewSecured = applicationContext.findAnnotationOnBean(beanName, PreAuthorize.class);
+
+        if ( viewSecured == null ) {
+            return true;
+        } else if ( security.hasAccessDecisionManager() ) {
+
+            final Class<?> targetClass = AopUtils.getTargetClass(applicationContext.getBean(beanName));
+            final Method method = ClassUtils.getMethod(AopUtils.getTargetClass(applicationContext.getBean(beanName)), "enter", com.vaadin.navigator.ViewChangeListener.ViewChangeEvent.class);
+            final MethodInvocation methodInvocation = MethodInvocationUtils.createFromClass(targetClass, method.getName());
+
+            final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            final AccessDecisionManager accessDecisionManager = security.getAccessDecisionManager();
+            final ExpressionBasedAnnotationAttributeFactory attributeFactory = new ExpressionBasedAnnotationAttributeFactory(new DefaultMethodSecurityExpressionHandler());
+
+            Collection<ConfigAttribute> atributi = new ArrayList<ConfigAttribute>();
+            atributi.add(attributeFactory.createPreInvocationAttribute(null, null, viewSecured.value()));
+
+            try {
+                accessDecisionManager.decide(authentication, methodInvocation, atributi);
+                return true;
+            } catch (InsufficientAuthenticationException e) {
+                return false;
+            } catch (AccessDeniedException e) {
+                return false;
+            }
+
+        } else {
+            return true; // Access decision manager required for @PreAuthorize()
+        }
+
+    }
+
+    /*
+     * If there is an access manager then the decision is already made 
+     */
+    @Override
+    public boolean isAccessGranted(View view, UI ui) {
+        return true;
+    }
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/PreAuthorizeViewProviderAccessDelegate.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/PreAuthorizeViewProviderAccessDelegate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security.provider;
 
 import java.lang.reflect.Method;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/SecuredViewProviderAccessDelegate.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/SecuredViewProviderAccessDelegate.java
@@ -34,7 +34,7 @@ import org.vaadin.spring.security.VaadinSecurityAware;
  * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
  * @see VaadinSecurity#hasAnyAuthority(String...)
  */
-public class SpringSecurityViewProviderAccessDelegate implements VaadinSecurityAware, ViewProviderAccessDelegate {
+public class SecuredViewProviderAccessDelegate implements VaadinSecurityAware, ViewProviderAccessDelegate {
 
     private VaadinSecurity security;
     private ApplicationContext applicationContext;

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/SpringSecurityViewProviderAccessDelegate.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/provider/SpringSecurityViewProviderAccessDelegate.java
@@ -44,12 +44,12 @@ public class SpringSecurityViewProviderAccessDelegate implements VaadinSecurityA
         security = vaadinSecurity;
         applicationContext = security.getApplicationContext();
     }
-    
+
     @Override
     public boolean isAccessGranted(String beanName, UI ui) {
-        
+
         Secured viewSecured = applicationContext.findAnnotationOnBean(beanName, Secured.class);
-        
+
         if ( viewSecured == null ) {
             return true;
         } else if ( security.hasAccessDecisionManager() ) {
@@ -62,7 +62,7 @@ public class SpringSecurityViewProviderAccessDelegate implements VaadinSecurityA
     @Override
     public boolean isAccessGranted(View view, UI ui) {
         Secured viewSecured = view.getClass().getAnnotation(Secured.class);
-        
+
         if ( viewSecured == null || !security.hasAccessDecisionManager() ) {
             return true; // Decision is already done if there is no AccessDecisionManager
         } else {

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/support/VaadinSecurityAwareProcessor.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/support/VaadinSecurityAwareProcessor.java
@@ -1,0 +1,85 @@
+package org.vaadin.spring.security.support;
+
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.Aware;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.vaadin.spring.security.VaadinSecurity;
+import org.vaadin.spring.security.VaadinSecurityAware;
+import org.vaadin.spring.security.VaadinSecurityContext;
+import org.vaadin.spring.security.VaadinSecurityContextAware;
+
+/**
+ * {@link org.springframework.beans.factory.config.BeanPostProcessor}
+ * implementation that passes the VaadinSecurity to beans that
+ * implement the {@link org.vaadin.spring.security.VaadinSecurityAware} interface
+ * 
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ * @since 12.23.2014
+ * @see org.vaadin.spring.security.VaadinSecurityAware
+ * @see org.springframework.context.support.ApplicationContextAwareProcessor
+ */
+public class VaadinSecurityAwareProcessor implements ApplicationContextAware, BeanPostProcessor {
+
+	private ConfigurableApplicationContext applicationContext;
+	
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+	}
+	
+	@Override
+	public Object postProcessBeforeInitialization(final Object bean, String beanName) throws BeansException {
+
+		AccessControlContext acc = null;
+
+		if ( System.getSecurityManager() != null && (bean instanceof VaadinSecurityAware) ) {
+			acc = this.applicationContext.getBeanFactory().getAccessControlContext();
+		}
+		
+		if (acc != null) {
+			AccessController.doPrivileged(new PrivilegedAction<Object>() {
+				
+				@Override
+				public Object run() {
+					invokeAwareInterfaces(bean);
+					return null;
+				}
+				
+			}, acc);
+		}
+		else {
+			invokeAwareInterfaces(bean);
+		}
+
+		return bean;
+		
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+	
+	private void invokeAwareInterfaces(Object bean) {
+		
+		if ( bean instanceof Aware ) {
+			
+			if ( bean instanceof VaadinSecurityAware ) {
+				((VaadinSecurityAware) bean).setVaadinSecurity(this.applicationContext.getBean(VaadinSecurity.class));
+			}
+		
+			if ( bean instanceof VaadinSecurityContextAware ) {
+				((VaadinSecurityContextAware) bean).setVaadinSecurityContext(this.applicationContext.getBean(VaadinSecurityContext.class));
+			}
+		}
+		
+	}
+
+}

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/support/VaadinSecurityAwareProcessor.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/support/VaadinSecurityAwareProcessor.java
@@ -27,59 +27,59 @@ import org.vaadin.spring.security.VaadinSecurityContextAware;
  */
 public class VaadinSecurityAwareProcessor implements ApplicationContextAware, BeanPostProcessor {
 
-	private ConfigurableApplicationContext applicationContext;
-	
-	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
-	}
-	
-	@Override
-	public Object postProcessBeforeInitialization(final Object bean, String beanName) throws BeansException {
+    private ConfigurableApplicationContext applicationContext;
 
-		AccessControlContext acc = null;
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+    }
 
-		if ( System.getSecurityManager() != null && (bean instanceof VaadinSecurityAware) ) {
-			acc = this.applicationContext.getBeanFactory().getAccessControlContext();
-		}
-		
-		if (acc != null) {
-			AccessController.doPrivileged(new PrivilegedAction<Object>() {
-				
-				@Override
-				public Object run() {
-					invokeAwareInterfaces(bean);
-					return null;
-				}
-				
-			}, acc);
-		}
-		else {
-			invokeAwareInterfaces(bean);
-		}
+    @Override
+    public Object postProcessBeforeInitialization(final Object bean, String beanName) throws BeansException {
 
-		return bean;
-		
-	}
+        AccessControlContext acc = null;
 
-	@Override
-	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-		return bean;
-	}
-	
-	private void invokeAwareInterfaces(Object bean) {
-		
-		if ( bean instanceof Aware ) {
-			
-			if ( bean instanceof VaadinSecurityAware ) {
-				((VaadinSecurityAware) bean).setVaadinSecurity(this.applicationContext.getBean(VaadinSecurity.class));
-			}
-		
-			if ( bean instanceof VaadinSecurityContextAware ) {
-				((VaadinSecurityContextAware) bean).setVaadinSecurityContext(this.applicationContext.getBean(VaadinSecurityContext.class));
-			}
-		}
-		
-	}
+        if ( System.getSecurityManager() != null && (bean instanceof VaadinSecurityAware) ) {
+            acc = this.applicationContext.getBeanFactory().getAccessControlContext();
+        }
+
+        if (acc != null) {
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+
+                @Override
+                public Object run() {
+                    invokeAwareInterfaces(bean);
+                    return null;
+                }
+
+            }, acc);
+        }
+        else {
+            invokeAwareInterfaces(bean);
+        }
+
+        return bean;
+
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    private void invokeAwareInterfaces(Object bean) {
+
+        if ( bean instanceof Aware ) {
+
+            if ( bean instanceof VaadinSecurityAware ) {
+                ((VaadinSecurityAware) bean).setVaadinSecurity(this.applicationContext.getBean(VaadinSecurity.class));
+            }
+
+            if ( bean instanceof VaadinSecurityContextAware ) {
+                ((VaadinSecurityContextAware) bean).setVaadinSecurityContext(this.applicationContext.getBean(VaadinSecurityContext.class));
+            }
+        }
+
+    }
 
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/support/VaadinSecurityAwareProcessor.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/support/VaadinSecurityAwareProcessor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.security.support;
 
 import java.security.AccessControlContext;

--- a/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/DefaultSecurityConfiguration.java
+++ b/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/DefaultSecurityConfiguration.java
@@ -1,0 +1,31 @@
+package org.vaadin.spring.security.test;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.vaadin.spring.security.annotation.EnableVaadinSecurity;
+import org.vaadin.spring.security.config.VaadinSecurityConfiguration;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@Configuration
+@EnableVaadinSecurity
+public class DefaultSecurityConfiguration {
+
+    @Bean(name = VaadinSecurityConfiguration.Beans.AUTHENTICATION_MANAGER)
+    public AuthenticationManager createAuthenticationManager() {
+        AuthenticationManager am = mock(AuthenticationManager.class);
+        when(am.authenticate(any(Authentication.class))).thenAnswer(new Answer<Authentication>() {
+            public Authentication answer(InvocationOnMock invocation) throws Throwable {
+                return (Authentication) invocation.getArguments()[0];
+            }
+        });
+
+        return am;
+    }
+    
+}

--- a/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/DefaultTestConfiguration.java
+++ b/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/DefaultTestConfiguration.java
@@ -1,0 +1,10 @@
+package org.vaadin.spring.security.test;
+
+import org.springframework.context.annotation.Configuration;
+import org.vaadin.spring.EnableVaadin;
+
+@Configuration
+@EnableVaadin
+public class DefaultTestConfiguration {
+    
+}

--- a/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/DependecyInjectionTest.java
+++ b/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/DependecyInjectionTest.java
@@ -1,0 +1,66 @@
+package org.vaadin.spring.security.test;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.vaadin.spring.security.VaadinSecurity;
+import org.vaadin.spring.security.VaadinSecurityContext;
+import org.vaadin.spring.test.VaadinAppConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test Security Bean Injection
+ * 
+ * @author Gert-Jan Timmer (gjr.timmer@gmail.com)
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@VaadinAppConfiguration
+@ContextConfiguration(classes = {DefaultTestConfiguration.class, DefaultSecurityConfiguration.class, DependecyInjectionTest.DependencyConfig.class})
+public class DependecyInjectionTest {
+    
+    @Autowired
+    ApplicationContext applicationContext;
+    
+    @Autowired
+    VaadinSecurity vaadinSecurity;
+    
+    @Autowired
+    VaadinSecurityContext vaadinSecurityContext;
+    
+    @Autowired
+    SecurityAwareClass securityAwareClass;
+    
+    @Test
+    public void testSecurityAutowiring() {
+        assertNotNull(vaadinSecurity);
+        assertNotNull(vaadinSecurityContext);
+        assertNotNull(securityAwareClass);
+        assertNotNull(securityAwareClass.getVaadinSecurity());
+        assertNotNull(securityAwareClass.getVaadinSecurityContext());
+    }
+    
+    @Test
+    public void testSecurityAware() {
+        VaadinSecurity vaadinSecurity = securityAwareClass.getVaadinSecurity();
+        assertEquals(applicationContext, vaadinSecurity.getApplicationContext());
+    }
+    
+    @Configuration
+    public static class DependencyConfig {
+        
+        @Bean
+        SecurityAwareClass securityAware() {
+            return new SecurityAwareClass();
+        }
+        
+    }
+
+}

--- a/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/SecurityAwareClass.java
+++ b/spring-vaadin-security/src/test/java/org/vaadin/spring/security/test/SecurityAwareClass.java
@@ -1,0 +1,39 @@
+package org.vaadin.spring.security.test;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+import org.vaadin.spring.security.VaadinSecurity;
+import org.vaadin.spring.security.VaadinSecurityAware;
+import org.vaadin.spring.security.VaadinSecurityContext;
+import org.vaadin.spring.security.VaadinSecurityContextAware;
+
+public class SecurityAwareClass implements InitializingBean, VaadinSecurityAware, VaadinSecurityContextAware {
+
+    private VaadinSecurity vaadinSecurity;
+    private VaadinSecurityContext vaadinSecurityContext;
+    
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull(vaadinSecurity);
+        Assert.notNull(vaadinSecurityContext);
+    }
+
+    @Override
+    public void setVaadinSecurity(VaadinSecurity vaadinSecurity) {
+        this.vaadinSecurity = vaadinSecurity;
+    }
+    
+    @Override
+    public void setVaadinSecurityContext(VaadinSecurityContext vaadinSecurityContext) {
+        this.vaadinSecurityContext = vaadinSecurityContext;
+    }
+
+    public VaadinSecurity getVaadinSecurity() {
+        return vaadinSecurity;
+    }
+
+    public VaadinSecurityContext getVaadinSecurityContext() {
+        return vaadinSecurityContext;
+    }
+
+}

--- a/spring-vaadin-security/src/test/resources/logback.xml
+++ b/spring-vaadin-security/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration debug="true">
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDERR"/>
+    </root>
+
+    <logger name="org.vaadin.spring.security" level="TRACE"/>
+</configuration>


### PR DESCRIPTION
Renamed Security => VaadinSecurity to avoid naming conflict with Spring-security.

VaadinSecurity (Former Security) changed from implementation to interface.
Implementation of former Security => GenericVaadinSecurity

Split VaadinSecurity (former Security) implementation; moved generic to AbstractVaadinSecurity
Added interface VaadinSecurityContext implementation => AbstractVaadinSecurity
PR #117 implemented => AbstractVaadinSecurity with interface VaadinSecurityContext

Added VaadinSecurityAware
Added VaadinSecurityContextAware
Added bean post processor for VaadinSecurityAware / VaadinSecurityContextAware

Updated VaadinSecurityConfiguration