### PR TITLE
Updated @UIScope => @VaadinUIScope

### DIFF
--- a/spring-vaadin-simple-mvp/src/test/java/org/vaadin/spring/mvp/autowired/AnnotatedFooView.java
+++ b/spring-vaadin-simple-mvp/src/test/java/org/vaadin/spring/mvp/autowired/AnnotatedFooView.java
@@ -1,10 +1,10 @@
 package org.vaadin.spring.mvp.autowired;
 
-import org.vaadin.spring.UIScope;
 import org.vaadin.spring.VaadinComponent;
+import org.vaadin.spring.VaadinUIScope;
 import org.vaadin.spring.mvp.FooView;
 
-@UIScope
+@VaadinUIScope
 @VaadinComponent
 public class AnnotatedFooView extends FooView {
 

--- a/spring-vaadin-simple-mvp/src/test/java/org/vaadin/spring/mvp/autowired/AutowiredPresenter.java
+++ b/spring-vaadin-simple-mvp/src/test/java/org/vaadin/spring/mvp/autowired/AutowiredPresenter.java
@@ -1,14 +1,14 @@
 package org.vaadin.spring.mvp.autowired;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.UIScope;
 import org.vaadin.spring.VaadinComponent;
+import org.vaadin.spring.VaadinUIScope;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventBusListenerMethod;
 import org.vaadin.spring.mvp.FooView;
 import org.vaadin.spring.mvp.Presenter;
 
-@UIScope
+@VaadinUIScope
 @VaadinComponent
 public class AutowiredPresenter extends Presenter<FooView> {
 

--- a/spring-vaadin-simple-mvp/src/test/java/org/vaadin/spring/mvp/explicit/ExplicitConfig.java
+++ b/spring-vaadin-simple-mvp/src/test/java/org/vaadin/spring/mvp/explicit/ExplicitConfig.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.vaadin.spring.EnableVaadin;
-import org.vaadin.spring.UIScope;
+import org.vaadin.spring.VaadinUIScope;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.mvp.FooView;
 
@@ -16,13 +16,13 @@ public class ExplicitConfig {
     private EventBus eventBus;
 
     @Bean
-    @UIScope
+    @VaadinUIScope
     public FooView fooView() {
         return new FooView();
     }
 
     @Bean
-    @UIScope
+    @VaadinUIScope
     public ExplicitPresenter fooPresenter() {
         return new ExplicitPresenter(fooView(), eventBus);
     }


### PR DESCRIPTION
Current @peholmst master has built errors when compile with

```
mvn clean package install
```

There are some minor errors due to the rename of @UIScope within the test classes of spring-vaadin-simple-mvp.

This fix corrects the test classes for succesfull testing and building