### PR TITLE
Gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ target/
 *.springBeans
 
 # Vaadin
-spring-boot-sample/src/main/public/VAADIN/widgetsets
-spring-boot-sample/src/main/resources/VAADIN/themes/sample/styles.css
-samples/push-sample/src/main/resources/VAADIN/widgetsets
-samples/mvp-sample/src/main/webapp/VAADIN/widgetsets
+samples/**/src/main/resources/VAADIN/widgetsets
+samples/**/src/main/webapp/VAADIN/themes/*.css
+samples/**/src/main/webapp/VAADIN/themes/**/*.css

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ target/
 *.springBeans
 
 # Vaadin
-samples/**/src/main/resources/VAADIN/widgetsets
-samples/**/src/main/webapp/VAADIN/themes/*.css
-samples/**/src/main/webapp/VAADIN/themes/**/*.css
+samples/*-sample/src/main/webapp/VAADIN/themes/*.css
+samples/*-sample/src/main/webapp/VAADIN/themes/**/*.css
+samples/*-sample/src/main/webapp/VAADIN/widgetsets/


### PR DESCRIPTION
Updated exclusions for the samples.
Using wildcards instead of hardcoding.

Reason:
Working on additional samples like security-sample