### PR TITLE
Development/security

### DIFF
--- a/spring-vaadin-security/pom.xml
+++ b/spring-vaadin-security/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>spring-vaadin</artifactId>
             <version>${project.version}</version>

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/AbstractVaadinSecurity.java
@@ -24,6 +24,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.util.Assert;
 
 /**
@@ -40,6 +42,7 @@ public abstract class AbstractVaadinSecurity implements ApplicationContextAware,
     private ApplicationContext applicationContext;
     private AuthenticationManager authenticationManager;
     private AccessDecisionManager accessDecisionManager;
+    private SessionAuthenticationStrategy sessionAuthenticationStrategy;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -60,9 +63,17 @@ public abstract class AbstractVaadinSecurity implements ApplicationContextAware,
             accessDecisionManager = null;
             logger.warn("No AccessDecisionManager set! Some security methods will not be available.");
         }
+        
+        SessionAuthenticationStrategy sessionAuthStrategy;
+        try {
+            sessionAuthStrategy = applicationContext.getBean(SessionAuthenticationStrategy.class);
+        } catch(NoSuchBeanDefinitionException e) {
+            sessionAuthStrategy = new NullAuthenticatedSessionStrategy();
+        }
 
         this.authenticationManager = authenticationManager;
         this.accessDecisionManager = accessDecisionManager;
+        this.sessionAuthenticationStrategy = sessionAuthStrategy;
     }
 
     @Override
@@ -95,6 +106,14 @@ public abstract class AbstractVaadinSecurity implements ApplicationContextAware,
     @Override
     public AccessDecisionManager getAccessDecisionManager() {
         return accessDecisionManager;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SessionAuthenticationStrategy getSessionAuthenticationStrategy() {
+        return sessionAuthenticationStrategy;
     }
 
     /**

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurity.java
@@ -130,4 +130,11 @@ public interface VaadinSecurity extends VaadinSecurityContext {
      */
     boolean hasAnyAuthority(String... authorities);
 
+    /**
+     * Allows the session attribute name to be customized for this repository instance.
+     *
+     * @param springSecurityContextKey the key under which the security context will be stored. Defaults to
+     * {@link #SPRING_SECURITY_CONTEXT_KEY}.
+     */
+    void setSpringSecurityContextKey(String springSecurityContextKey);
 }

--- a/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
+++ b/spring-vaadin-security/src/main/java/org/vaadin/spring/security/VaadinSecurityContext.java
@@ -18,6 +18,7 @@ package org.vaadin.spring.security;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
 /**
  * Interface which provides access to basic Security Context objects.
@@ -50,6 +51,14 @@ public interface VaadinSecurityContext {
      */
     AccessDecisionManager getAccessDecisionManager();
 
+    /**
+     * Get the configured {@link SessionAuthenticationStrategy}
+     * return {@link NullAuthenticatedSessionStrategy} if not configured
+     * 
+     * @return {@link SessionAuthenticationStrategy}
+     */
+    SessionAuthenticationStrategy getSessionAuthenticationStrategy();
+    
     /** 
      * Checks if the Security bean has an accessDecisionManager
      * 


### PR DESCRIPTION
Rewrite login()
 - SecurityContext now gets cleared because of further processing of the SpringSecurityFilterChain
 - Error is thrown up afterwards
 - After successful authentication the SessionAuthenticationStrategy is signaled about the new successful login
 - The SecurityContext is stored within the HttpSession for further use by the SpringSecurityFilterChain