### PR TITLE
Portlets support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <email>gjr.timmer@gmail.com</email>
         </developer>
         <developer>
+            <name>Idel Pivnitskiy</name>
+            <email>idel.pivnitskiy@gmail.com</email>
+        </developer>
+        <developer>
             <name>Josh Long</name>
             <email>josh@joshlong.com</email>
         </developer>
@@ -103,6 +107,11 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc-portlet</artifactId>
                 <version>${spring.version}</version>
             </dependency>
             <dependency>
@@ -174,6 +183,11 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.portlet</groupId>
+                <artifactId>portlet-api</artifactId>
+                <version>2.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -321,5 +335,6 @@
         <module>spring-vaadin-sidebar</module>
         <module>spring-vaadin-i18n</module>
         <module>spring-vaadin-eventbus</module>
+        <module>spring-vaadin-portlet</module>
     </modules>
 </project>

--- a/spring-vaadin-portlet/README.md
+++ b/spring-vaadin-portlet/README.md
@@ -1,0 +1,72 @@
+Vaadin4Spring Portlet Support
+===
+
+This add-on helps you to start quick development of your portlets with Vaadin and Spring.
+
+Create a new UI class in your project and annotate it with `@VaadinPortletUI` e.g. like this:
+```java
+@VaadinPortletUI
+public class MyVaadinPortletUI extends UI {
+    @Override
+    protected void init(VaadinRequest vaadinRequest) {
+        setContent(new Label("Hello! This is a simple portlet with Spring support!"));
+    }
+}
+```
+You should also add information about your portlet to `portlet.xml`:
+```xml
+<portlet>
+    <description>An example portlet to show Spring integration to Vaadin</description>
+    <portlet-name>Vaadin + Spring Portlet Example</portlet-name>
+    <display-name>Vaadin + Spring Portlet</display-name>
+
+    <!-- Map portlet to a servlet -->
+    <portlet-class>org.vaadin.spring.portlet.SpringAwareVaadinPortlet</portlet-class>
+    <init-param>
+        <name>UI</name>
+        <!-- The application class with package name -->
+        <value>com.example.myportlet.MyVaadinPortletUI</value>
+    </init-param>
+
+    <!-- Supported portlet modes and content types -->
+    <supports>
+        <mime-type>text/html</mime-type>
+        <portlet-mode>VIEW</portlet-mode>
+        <portlet-mode>edit</portlet-mode>
+        <portlet-mode>help</portlet-mode>
+    </supports>
+
+    <!-- Not always required but Liferay requires these -->
+    <portlet-info>
+        <title>Vaadin + Spring Portlet</title>
+        <keywords>vaadin</keywords>
+    </portlet-info>
+</portlet>
+```
+Read more information about portal integration in [Book of Vaadin](https://vaadin.com/book/-/page/portal.html).
+
+The simplest way to add Spring initialization in your application is a class which will extend
+`AbstractContextLoaderInitializer`:
+```java
+public class YourSpringWebContextInitializer extends AbstractContextLoaderInitializer {
+
+    @Override
+    protected WebApplicationContext createRootApplicationContext() {
+        AnnotationConfigWebApplicationContext applicationContext = new AnnotationConfigWebApplicationContext();
+        applicationContext.register(YourApplicationConfiguration.class);
+        return applicationContext;
+    }
+}
+```
+`YourApplicationConfiguration` should also import `VaadinConfiguration` to enable Vaadin UI Scope and other
+features of `spring-vaadin` add-on:
+```java
+@Configuration
+@Import(VaadinConfiguration.class)
+@ComponentScan(basePackages = {"com.example.myportlet" /*, ...other packages with Spring beans... */})
+public class YourApplicationConfiguration {
+    //...
+    //Your condiguration of DataSource, SessionFactory, TransactionManager, etc.
+    //...
+}
+```

--- a/spring-vaadin-portlet/pom.xml
+++ b/spring-vaadin-portlet/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.vaadin.spring</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>0.0.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>spring-vaadin-portlet</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Vaadin4Spring Portlet</name>
+
+  <developers>
+    <developer>
+      <name>Idel Pivnitskiy</name>
+      <email>idel.pivnitskiy@gmail.com</email>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.portlet</groupId>
+      <artifactId>portlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc-portlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.vaadin.spring</groupId>
+      <artifactId>spring-vaadin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.18</version>
+        <executions>
+          <execution>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/spring-vaadin-portlet/src/main/java/org/vaadin/spring/annotation/VaadinPortletUI.java
+++ b/spring-vaadin-portlet/src/main/java/org/vaadin/spring/annotation/VaadinPortletUI.java
@@ -1,0 +1,28 @@
+package org.vaadin.spring.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be put on {@link com.vaadin.ui.UI}-subclasses that are to be automatically detected and configured
+ * by Spring. Use it like this:
+ * <pre>
+ *     &#64;VaadinPortletUI
+ *     public class MyRootPortletUI extends UI {
+ *         // ...
+ *     }
+ * </pre>
+ *
+ * The annotated UI will automatically be placed in the {@link org.vaadin.spring.annotation.VaadinUIScope},
+ * so there is no need to add that annotation explicitly.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@VaadinComponent
+@VaadinUIScope
+public @interface VaadinPortletUI {
+}

--- a/spring-vaadin-portlet/src/main/java/org/vaadin/spring/portlet/SpringAwareUIProvider.java
+++ b/spring-vaadin-portlet/src/main/java/org/vaadin/spring/portlet/SpringAwareUIProvider.java
@@ -1,0 +1,89 @@
+package org.vaadin.spring.portlet;
+
+import com.vaadin.server.UIClassSelectionEvent;
+import com.vaadin.server.UICreateEvent;
+import com.vaadin.server.UIProvider;
+import com.vaadin.server.VaadinSession;
+import com.vaadin.ui.UI;
+import com.vaadin.util.CurrentInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.vaadin.spring.annotation.VaadinPortletUI;
+import org.vaadin.spring.internal.UIID;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Vaadin {@link com.vaadin.server.UIProvider} that looks up UI classes from the Spring application context. The UI
+ * classes must be annotated with {@link org.vaadin.spring.annotation.VaadinPortletUI}.
+ */
+public class SpringAwareUIProvider extends UIProvider {
+    private static final long serialVersionUID = -6195911893325385491L;
+
+    private static final Logger logger = LoggerFactory.getLogger(SpringAwareUIProvider.class);
+
+    private final Map<String, Class<? extends UI>> uiNameToUiClassMap = new ConcurrentHashMap<String, Class<? extends UI>>();
+
+    private final ApplicationContext applicationContext;
+
+    public SpringAwareUIProvider(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        detectUIs();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void detectUIs() {
+        logger.info("Checking the application context for Vaadin UIs");
+        final String[] uiBeanNames = applicationContext.getBeanNamesForAnnotation(VaadinPortletUI.class);
+        for (String uiBeanName : uiBeanNames) {
+            Class<?> beanType = applicationContext.getType(uiBeanName);
+            if (UI.class.isAssignableFrom(beanType)) {
+                String uiClassName = beanType.getName();
+                int endIndex = uiClassName.indexOf('$');    //exclude AspectJ proxy class name
+                if (endIndex > 0) {
+                    uiClassName = uiClassName.substring(0, endIndex);
+                }
+                logger.info("Found Vaadin UI [{}]", uiClassName);
+                Class<? extends UI> existingBeanType = uiNameToUiClassMap.get(uiClassName);
+                if (existingBeanType != null) {
+                    throw new IllegalStateException(String.format("[%s] is already mapped to the UI [%s]",
+                            existingBeanType.getCanonicalName(), uiClassName));
+                }
+                logger.debug("Mapping Vaadin UI [{}] to uiClassName [{}]", beanType.getCanonicalName(), uiClassName);
+                Class<? extends UI> uiClass = (Class<? extends UI>) beanType;
+                uiNameToUiClassMap.put(uiClassName, uiClass);
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends UI> getUIClass(UIClassSelectionEvent event) {
+        Object uiClassNameObj = event.getService()
+                .getDeploymentConfiguration()
+                .getApplicationOrSystemProperty(VaadinSession.UI_PARAMETER, null);
+
+        if (uiClassNameObj instanceof String) {
+            String uiClassName = uiClassNameObj.toString();
+            return uiNameToUiClassMap.get(uiClassName);
+        }
+        return null;
+    }
+
+    @Override
+    public UI createInstance(UICreateEvent event) {
+        final Class<UIID> key = UIID.class;
+        final UIID identifier = new UIID(event);
+        CurrentInstance.set(key, identifier);
+        try {
+            Class<? extends UI> uiClass = event.getUIClass();
+            logger.debug("Creating a new UI bean of class [{}] with identifier [{}]",
+                    uiClass.getCanonicalName(), identifier);
+            return applicationContext.getBean(uiClass);
+        } finally {
+            CurrentInstance.set(key, null);
+        }
+    }
+}

--- a/spring-vaadin-portlet/src/main/java/org/vaadin/spring/portlet/SpringAwareVaadinPortlet.java
+++ b/spring-vaadin-portlet/src/main/java/org/vaadin/spring/portlet/SpringAwareVaadinPortlet.java
@@ -1,0 +1,40 @@
+package org.vaadin.spring.portlet;
+
+import com.vaadin.server.ServiceException;
+import com.vaadin.server.SessionInitEvent;
+import com.vaadin.server.SessionInitListener;
+import com.vaadin.server.VaadinPortlet;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.portlet.context.PortletApplicationContextUtils;
+
+import javax.portlet.PortletException;
+
+/**
+ * Subclass of the standard {@link com.vaadin.server.VaadinPortlet Vaadin portlet} that adds a
+ * {@link org.vaadin.spring.portlet.SpringAwareUIProvider} to every new Vaadin session.
+ *
+ * <p>If you need a custom Vaadin portlet, you can either extend this portlet directly, or extend another subclass of
+ * {@link com.vaadin.server.VaadinServlet} and just add the UI provider.</p>
+ */
+public class SpringAwareVaadinPortlet extends VaadinPortlet {
+    private static final long serialVersionUID = 481506148953544624L;
+
+    @Override
+    protected void portletInitialized() throws PortletException {
+        getService().addSessionInitListener(new SessionInitListener() {
+            private static final long serialVersionUID = -4571879262155039969L;
+
+            @Override
+            public void sessionInit(SessionInitEvent event) throws ServiceException {
+                try {
+                    ApplicationContext context = PortletApplicationContextUtils
+                            .getRequiredWebApplicationContext(getPortletContext());
+                    SpringAwareUIProvider uiProvider = new SpringAwareUIProvider(context);
+                    event.getSession().addUIProvider(uiProvider);
+                } catch (IllegalStateException e) {
+                    throw new ServiceException(e);
+                }
+            }
+        });
+    }
+}

--- a/spring-vaadin-portlet/src/test/resources/logback.xml
+++ b/spring-vaadin-portlet/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration debug="true">
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDERR"/>
+    </root>
+
+    <logger name="org.vaadin.spring" level="TRACE"/>
+</configuration>


### PR DESCRIPTION
This module adds support for portlets and is based on ideas of `spring-vaadin` module for servlets.
Tested on GateIn portal 3.8.1.Final.
See issue #137.
