### PR TITLE
Added ./VAADIN/** to the matchers to allow loading of widgetsets.

### DIFF
--- a/samples/security-sample/src/main/java/org/vaadin/spring/samples/security/config/SecurityConfiguration.java
+++ b/samples/security-sample/src/main/java/org/vaadin/spring/samples/security/config/SecurityConfiguration.java
@@ -130,6 +130,7 @@ public class SecurityConfiguration {
             http
                 .authorizeRequests()
                     .antMatchers("/login/**").permitAll()
+                    .antMatchers("/VAADIN/**").permitAll()
                     .antMatchers("/UIDL/**").permitAll()
                     .antMatchers("/HEARTBEAT/**").authenticated()
                     .antMatchers("/**").authenticated()


### PR DESCRIPTION
I had to add this to my SecurityConfiguration in order to be able to see the login screen. Before, the widgetset was not loading due to a 404 message on the client end.