### PR TITLE
Extends event bus to accept target strings (publish and method annoration)

### DIFF
--- a/addons/eventbus/README.md
+++ b/addons/eventbus/README.md
@@ -36,6 +36,10 @@ creating a singleton instance of ```ApplicationContextEventBroker```:
  }
 ```    
 
+# Event Bus Topics
+Events can be published with a string based topic. This will distinguish which listener methods will be called.
+Therefore a topic must be provided when publishing events and at the listener methods.
+
 # Injecting the Event Bus
 
 The event bus is automatically enabled when you enable the Spring4Vaadin add-on. You can just autowire in an instance
@@ -80,7 +84,9 @@ Example:
  ...
  myUIScopedEventBus.publish(this, "This will be published on the UI scoped event bus");
  myUIScopedEventBus.publish(EventScope.SESSION, this, "This will be published on the session scoped event bus");
-```
+ myUIScopedEventBus.publish("myTopic", this, "This will be published on the UI scoped event bus within the topic myTopic");
+ myUIScopedEventBus.publish("myTopic",EventScope.SESSION, this, "This will be published on the session scoped event bus  within the topic myTopic");
+ ```
 
 # Receiving Events
 
@@ -98,10 +104,29 @@ When subscribing to an event bus, you can also define whether you want to receiv
 this is true, which means that events published on the parent event buses will also be delivered to the subscriber. If
 false, only events published on that particular event bus will be delivered.
 
+To specify a topic, the listener method must be annotated with the ```@EventBusListenerTopic``` additionally.
+There it's possible to set the listener topic and an implementation of the ```TopicFilter``` interface to define how 
+to evaluate the topic matching.
+
+```java
+ @EventBusListenerTopic(topic = "myTopic")
+ @EventBusListenerMethod()
+ public void myListener(MyPayload payload) {...}
+ ```
+or width a custom filter implementation 
+
+```java
+ @EventBusListenerTopic(topic = "myTopic", filter = MyCustomTopicFilter.class)
+ @EventBusListenerMethod()
+ public void myListener(MyPayload payload) {...}
+ ```
+
 ## Known Limitations
 
 Currently, you cannot use JDK 8 lambdas to subscribe to events. This has to do with the way
 the payload is currently deduced (issue #44).
+
+The topics will only work with the annotation based listeners, see ``@EventBusListenerMethod```.
 
 # More Information
 

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/Event.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/Event.java
@@ -37,11 +37,15 @@ public class Event<T> implements Serializable {
 
     private final T payload;
 
+    public Event(EventBus eventBus, Object source, T payload) {
+    	this(eventBus, source, payload, "");
+    }
+
     public Event(EventBus eventBus, Object source, T payload, String target) {
         this.eventBus = eventBus;
         this.source = source;
         this.payload = payload;
-        this.target = target;
+        this.target = target != null ? target : "";
         this.timestamp = System.currentTimeMillis();
     }
 

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/Event.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/Event.java
@@ -31,14 +31,17 @@ public class Event<T> implements Serializable {
 
     private final Object source;
 
+    private final String target;
+    
     private final long timestamp;
 
     private final T payload;
 
-    public Event(EventBus eventBus, Object source, T payload) {
+    public Event(EventBus eventBus, Object source, T payload, String target) {
         this.eventBus = eventBus;
         this.source = source;
         this.payload = payload;
+        this.target = target;
         this.timestamp = System.currentTimeMillis();
     }
 
@@ -69,6 +72,15 @@ public class Event<T> implements Serializable {
         return source;
     }
 
+    /**
+     * Gets the string which specifies the target of the event on the event bus.
+     * 
+     * @return the target of the event, never {@code null}.
+     */
+    public String getTarget() {
+		return target;
+	}
+    
     /**
      * Gets the timestamp when the event was published on the event bus.
      *

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/Event.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/Event.java
@@ -31,7 +31,7 @@ public class Event<T> implements Serializable {
 
     private final Object source;
 
-    private final String target;
+    private final String topic;
     
     private final long timestamp;
 
@@ -41,11 +41,11 @@ public class Event<T> implements Serializable {
     	this(eventBus, source, payload, "");
     }
 
-    public Event(EventBus eventBus, Object source, T payload, String target) {
+    public Event(EventBus eventBus, Object source, T payload, String topic) {
         this.eventBus = eventBus;
         this.source = source;
         this.payload = payload;
-        this.target = target != null ? target : "";
+        this.topic = topic != null ? topic : "";
         this.timestamp = System.currentTimeMillis();
     }
 
@@ -77,12 +77,12 @@ public class Event<T> implements Serializable {
     }
 
     /**
-     * Gets the string which specifies the target of the event on the event bus.
+     * Gets the string which specifies the topic of the event on the event bus.
      * 
-     * @return the target of the event, never {@code null}.
+     * @return the topic of the event, never {@code null}.
      */
-    public String getTarget() {
-		return target;
+    public String getTopic() {
+		return topic;
 	}
     
     /**

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
@@ -61,13 +61,13 @@ public interface EventBus {
     /**
      * Publishes the specified payload on the event bus, using the scope of this particular event bus.
      *
-     * @param target  the target of the event to publish, never {@code null}.
+     * @param target  the topic of the event to publish, never {@code null}.
      * @param sender  the object that published the event, never {@code null}.
      * @param payload the payload of the event to publish, never {@code null}.
      * @param <T>     the type of the payload.
      * @see #getScope()
      */
-    <T> void publish(String target, Object sender, T payload);
+    <T> void publish(String topic, Object sender, T payload);
 
     /**
      * Publishes the specified payload on the event bus, or any of its parent buses, depending on the event scope.
@@ -84,7 +84,7 @@ public interface EventBus {
     /**
      * Publishes the specified payload on the event bus, or any of its parent buses, depending on the event scope.
      *
-     * @param target  the target of the event to publish, never {@code null}.
+     * @param topic  the topic of the event to publish, never {@code null}.
      * @param scope   the scope of the event, never {@code null}.
      * @param sender  the object that published the event, never {@code null}.
      * @param payload the payload of the event to publish, never {@code null}.
@@ -92,7 +92,7 @@ public interface EventBus {
      * @throws UnsupportedOperationException if the payload could not be published with the specified scope.
      * @see #publish(Object, Object)
      */
-    <T> void publish(EventScope scope, String target, Object sender, T payload) throws UnsupportedOperationException;
+    <T> void publish(EventScope scope, String topic, Object sender, T payload) throws UnsupportedOperationException;
 
     /**
      * Gets the scope of the events published on this event bus.

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
@@ -59,6 +59,17 @@ public interface EventBus {
     <T> void publish(Object sender, T payload);
 
     /**
+     * Publishes the specified payload on the event bus, using the scope of this particular event bus.
+     *
+     * @param target  the target of the event to publish, never {@code null}.
+     * @param sender  the object that published the event, never {@code null}.
+     * @param payload the payload of the event to publish, never {@code null}.
+     * @param <T>     the type of the payload.
+     * @see #getScope()
+     */
+    <T> void publish(String target, Object sender, T payload);
+
+    /**
      * Publishes the specified payload on the event bus, or any of its parent buses, depending on the event scope.
      *
      * @param scope   the scope of the event, never {@code null}.
@@ -69,6 +80,19 @@ public interface EventBus {
      * @see #publish(Object, Object)
      */
     <T> void publish(EventScope scope, Object sender, T payload) throws UnsupportedOperationException;
+
+    /**
+     * Publishes the specified payload on the event bus, or any of its parent buses, depending on the event scope.
+     *
+     * @param target  the target of the event to publish, never {@code null}.
+     * @param scope   the scope of the event, never {@code null}.
+     * @param sender  the object that published the event, never {@code null}.
+     * @param payload the payload of the event to publish, never {@code null}.
+     * @param <T>     the type of the payload;
+     * @throws UnsupportedOperationException if the payload could not be published with the specified scope.
+     * @see #publish(Object, Object)
+     */
+    <T> void publish(EventScope scope, String target, Object sender, T payload) throws UnsupportedOperationException;
 
     /**
      * Gets the scope of the events published on this event bus.

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
@@ -60,8 +60,9 @@ public interface EventBus {
 
     /**
      * Publishes the specified payload on the event bus, using the scope of this particular event bus.
+     * The topic specifies which listeners will be notified.
      *
-     * @param target  the topic of the event to publish, never {@code null}.
+     * @param topic   the topic of the event to publish, never {@code null}.
      * @param sender  the object that published the event, never {@code null}.
      * @param payload the payload of the event to publish, never {@code null}.
      * @param <T>     the type of the payload.
@@ -83,8 +84,9 @@ public interface EventBus {
 
     /**
      * Publishes the specified payload on the event bus, or any of its parent buses, depending on the event scope.
+     * The topic specifies which listeners will be notified.
      *
-     * @param topic  the topic of the event to publish, never {@code null}.
+     * @param topic   the topic of the event to publish, never {@code null}.
      * @param scope   the scope of the event, never {@code null}.
      * @param sender  the object that published the event, never {@code null}.
      * @param payload the payload of the event to publish, never {@code null}.

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/ExactTopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/ExactTopicFilter.java
@@ -2,9 +2,9 @@ package org.vaadin.spring.events;
 
 public class ExactTopicFilter implements TopicFilter {
 
-	@Override
-	public boolean validTobic(String eventTopic, String listenerTopic) {
-		return eventTopic.equals(listenerTopic);
-	}
+    @Override
+    public boolean validTopic(String eventTopic, String listenerTopic) {
+        return eventTopic.equals(listenerTopic);
+    }
 
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/ExactTopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/ExactTopicFilter.java
@@ -1,5 +1,26 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.events;
 
+/**
+ * An implementation of {@link org.vaadin.spring.events.TopicFilter}
+ * which validates the topics with an exact match (equals).
+ * 
+ * @author Marco Luthardt (marco.luthardt@iandme.net)
+ */
 public class ExactTopicFilter implements TopicFilter {
 
     @Override

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/ExactTopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/ExactTopicFilter.java
@@ -1,0 +1,10 @@
+package org.vaadin.spring.events;
+
+public class ExactTopicFilter implements TopicFilter {
+
+	@Override
+	public boolean validTobic(String eventTopic, String listenerTopic) {
+		return eventTopic.equals(listenerTopic);
+	}
+
+}

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/HierachyTopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/HierachyTopicFilter.java
@@ -1,5 +1,34 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.events;
 
+/**
+ * An implementation of {@link org.vaadin.spring.events.TopicFilter}
+ * which validates the topics hierarchical. This means, that the
+ * listener filter will be checked as prefixed substring against
+ * the event topic.
+ * 
+ * <ol>
+ *   <li>match: <code>eventTopic = "foo.bar"</code> and <code>listenerTopic = "foo"</code></li>
+ *   <li>no match: <code>eventTopic = "foo"</code> and <code>listenerTopic = "foo.bar"</code></li>
+ *   <li>no match: <code>eventTopic = "foo.bar"</code> and <code>listenerTopic = "foo.not"</code></li>
+ * </ol>
+ * 
+ * @author Marco Luthardt (marco.luthardt@iandme.net)
+ */
 public class HierachyTopicFilter implements TopicFilter {
 
     @Override

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/HierachyTopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/HierachyTopicFilter.java
@@ -1,0 +1,10 @@
+package org.vaadin.spring.events;
+
+public class HierachyTopicFilter implements TopicFilter {
+
+	@Override
+	public boolean validTobic(String eventTopic, String listenerTopic) {
+		return eventTopic.startsWith(listenerTopic);
+	}
+
+}

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/HierachyTopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/HierachyTopicFilter.java
@@ -2,9 +2,8 @@ package org.vaadin.spring.events;
 
 public class HierachyTopicFilter implements TopicFilter {
 
-	@Override
-	public boolean validTobic(String eventTopic, String listenerTopic) {
-		return eventTopic.startsWith(listenerTopic);
-	}
-
+    @Override
+    public boolean validTopic(String eventTopic, String listenerTopic) {
+        return eventTopic.startsWith(listenerTopic);
+    }
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/TopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/TopicFilter.java
@@ -2,6 +2,6 @@ package org.vaadin.spring.events;
 
 public interface TopicFilter {
 
-	boolean validTobic(String eventTopic, String listenerTopic);
-	
+    boolean validTopic(String eventTopic, String listenerTopic);
+
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/TopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/TopicFilter.java
@@ -1,0 +1,7 @@
+package org.vaadin.spring.events;
+
+public interface TopicFilter {
+
+	boolean validTobic(String eventTopic, String listenerTopic);
+	
+}

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/TopicFilter.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/TopicFilter.java
@@ -1,7 +1,40 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.events;
 
+/**
+ * The interface defines a method to validate a given event topic
+ * an listener topic. The event topic is provided when publishing
+ * an event and the listener topic by the {@link org.vaadin.spring.events.annotation.EventBusListenerTopic} 
+ * annotation. An implementation of this interface can be used as 
+ * parameter of this annotation.
+ * 
+ * @author Marco Luthardt (marco.luthardt@iandme.net)
+ * @see org.vaadin.spring.events.annotation.EventBusListenerTopic
+ */
 public interface TopicFilter {
 
+    /**
+     * Validates the given event topic against the listener topic.
+     * 
+     * @param eventTopic    the topic provided by while publishing an event, never {@code null}
+     * @param listenerTopic the topic of the listener method, never {@code null}
+     * 
+     * @return true true if the event topic matches the listener topic, otherwise false
+     */
     boolean validTopic(String eventTopic, String listenerTopic);
 
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerMethod.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerMethod.java
@@ -49,4 +49,10 @@ public @interface EventBusListenerMethod {
 
     Class<? extends EventBusListenerMethodFilter> filter() default NoEventBusListenerMethodFilter.class;
 
+    /**
+     * A target is a String which can be specified while publishing an event. The method
+     * will only called when the target matches the given String in the published method.
+     */
+    String target() default "";
+
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerMethod.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerMethod.java
@@ -55,4 +55,10 @@ public @interface EventBusListenerMethod {
      */
     String target() default "";
 
+    /**
+     * If this value is set to true, the defined target of the receiver method must only
+     * be prefixed substring to get accepted as target method. Otherwise the target string
+     * must be equal to the published target.
+     */
+    boolean targetMatchPrefix() default false;
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerMethod.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerMethod.java
@@ -48,17 +48,4 @@ public @interface EventBusListenerMethod {
     EventScope scope() default EventScope.UNDEFINED;
 
     Class<? extends EventBusListenerMethodFilter> filter() default NoEventBusListenerMethodFilter.class;
-
-    /**
-     * A target is a String which can be specified while publishing an event. The method
-     * will only called when the target matches the given String in the published method.
-     */
-    String target() default "";
-
-    /**
-     * If this value is set to true, the defined target of the receiver method must only
-     * be prefixed substring to get accepted as target method. Otherwise the target string
-     * must be equal to the published target.
-     */
-    boolean targetMatchPrefix() default false;
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerTopic.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerTopic.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 The original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.spring.events.annotation;
 
 import java.lang.annotation.Documented;
@@ -9,18 +24,36 @@ import java.lang.annotation.Target;
 import org.vaadin.spring.events.ExactTopicFilter;
 import org.vaadin.spring.events.TopicFilter;
 
+/**
+ * Annotation to be placed on event bus listener methods, additional to
+ * the {@link org.vaadin.spring.events.annotation.EventBusListenerMethod} annotation.
+ * A topic is specified as string which will be defined when publishing an event.
+ * Each method annotated with this annotation and the corresponding topic will be
+ * called as listener.
+ * 
+ * Topics can be filtered with implementations of the {@link org.vaadin.spring.events.TopicFilter} interface.
+ * 
+ * @author Marco Luthardt (marco.luthardt@iandme.net)
+ * @see org.vaadin.spring.events.annotation.EventBusListenerMethod
+ * @see org.vaadin.spring.events.TopicFilter
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface EventBusListenerTopic {
 
     /**
-     * A topic is a String which can be specified while publishing an event. The
+     * A topic is a string which can be specified while publishing an event. The
      * method will only called when the topic matches the given String in the
      * published method.
      */
     String topic() default "";
 
+    /**
+     * The filter to be used to validate the published and listener topic.
+     * 
+     * @return an implementation of the {@link org.vaadin.spring.events.TopicFilter} interface.
+     */
     Class<? extends TopicFilter> filter() default ExactTopicFilter.class;
 
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerTopic.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerTopic.java
@@ -1,0 +1,25 @@
+package org.vaadin.spring.events.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.vaadin.spring.events.ExactTopicFilter;
+import org.vaadin.spring.events.TopicFilter;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface EventBusListenerTopic {
+
+    /**
+     * A topic is a String which can be specified while publishing an event. The method
+     * will only called when the topic matches the given String in the published method.
+     */
+	String topic() default "";
+	
+    Class<? extends TopicFilter> filter() default ExactTopicFilter.class;
+
+}

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerTopic.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/annotation/EventBusListenerTopic.java
@@ -15,11 +15,12 @@ import org.vaadin.spring.events.TopicFilter;
 public @interface EventBusListenerTopic {
 
     /**
-     * A topic is a String which can be specified while publishing an event. The method
-     * will only called when the topic matches the given String in the published method.
+     * A topic is a String which can be specified while publishing an event. The
+     * method will only called when the topic matches the given String in the
+     * published method.
      */
-	String topic() default "";
-	
+    String topic() default "";
+
     Class<? extends TopicFilter> filter() default ExactTopicFilter.class;
 
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
@@ -99,13 +99,16 @@ class MethodListenerWrapper extends AbstractListenerWrapper {
                 EventBusListenerMethod annotation = listenerMethod.getAnnotation(EventBusListenerMethod.class);
                 EventBusListenerMethodFilter filter = annotation.filter().newInstance();
                 String target = annotation.target();
+                boolean isTarget = annotation.targetMatchPrefix() 
+                        ? event.getTarget().startsWith(target) 
+                        : target.equals(event.getTarget());
                 EventScope scope = annotation.scope();
                 if (scope.equals(EventScope.UNDEFINED)) {
                     scope = event.getScope();
                 }
-                supports = supports && filter.filter(event.getPayload())
-                        && event.getScope().equals(scope)
-                        && event.getTarget().startsWith(target);
+                supports = supports && isTarget 
+                        && filter.filter(event.getPayload())
+                        && event.getScope().equals(scope);
             }
         } catch (Exception e) {
             throw new RuntimeException("A checked exception occurred while invoking listener method " + listenerMethod.getName(), e);

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
@@ -26,7 +26,9 @@ import org.vaadin.spring.events.Event;
 import org.vaadin.spring.events.EventBus;
 import org.vaadin.spring.events.EventBusListenerMethodFilter;
 import org.vaadin.spring.events.EventScope;
+import org.vaadin.spring.events.TopicFilter;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
+import org.vaadin.spring.events.annotation.EventBusListenerTopic;
 
 /**
  * Implementation of {@link org.vaadin.spring.events.internal.AbstractListenerWrapper} that wraps an object
@@ -96,24 +98,57 @@ class MethodListenerWrapper extends AbstractListenerWrapper {
         boolean supports = super.supports(event);
         try {
             if (listenerMethod.isAnnotationPresent(EventBusListenerMethod.class)) {
-                EventBusListenerMethod annotation = listenerMethod.getAnnotation(EventBusListenerMethod.class);
-                EventBusListenerMethodFilter filter = annotation.filter().newInstance();
-                String target = annotation.target();
-                boolean isTarget = annotation.targetMatchPrefix() 
-                        ? event.getTarget().startsWith(target) 
-                        : target.equals(event.getTarget());
-                EventScope scope = annotation.scope();
-                if (scope.equals(EventScope.UNDEFINED)) {
-                    scope = event.getScope();
-                }
-                supports = supports && isTarget 
-                        && filter.filter(event.getPayload())
-                        && event.getScope().equals(scope);
+                supports = supports && isInterestedListenerMethod(event);
             }
+        	if (listenerMethod.isAnnotationPresent(EventBusListenerTopic.class) && supports) {
+        		supports = isInTopic(event);
+        	}
         } catch (Exception e) {
             throw new RuntimeException("A checked exception occurred while invoking listener method " + listenerMethod.getName(), e);
         }
         return supports;
     }
+
+    private boolean isInterestedListenerMethod(Event<?> event) throws InstantiationException, IllegalAccessException {
+        EventBusListenerMethod annotation = listenerMethod.getAnnotation(EventBusListenerMethod.class);
+        EventBusListenerMethodFilter filter = annotation.filter().newInstance();
+        EventScope scope = annotation.scope();
+        if (scope.equals(EventScope.UNDEFINED)) {
+            scope = event.getScope();
+        }
+        return filter.filter(event.getPayload())
+                && event.getScope().equals(scope);
+    }
+    
+    private boolean isInTopic(Event<?> event) throws InstantiationException, IllegalAccessException {
+        EventBusListenerTopic annotation = listenerMethod.getAnnotation(EventBusListenerTopic.class);
+        TopicFilter filter = annotation.filter().newInstance();
+        return filter.validTobic(event.getTopic(), annotation.topic());
+    }    
+    
+//    @Override
+//    public boolean supports(Event<?> event) {
+//        boolean supports = super.supports(event);
+//        try {
+//            if (listenerMethod.isAnnotationPresent(EventBusListenerMethod.class)) {
+//                EventBusListenerMethod annotation = listenerMethod.getAnnotation(EventBusListenerMethod.class);
+//                EventBusListenerMethodFilter filter = annotation.filter().newInstance();
+////                String target = annotation.target();
+////                boolean isTarget = annotation.targetMatchPrefix() 
+////                        ? event.getTarget().startsWith(target) 
+////                        : target.equals(event.getTarget());
+//                EventScope scope = annotation.scope();
+//                if (scope.equals(EventScope.UNDEFINED)) {
+//                    scope = event.getScope();
+//                }
+//                supports = supports 
+//                        && filter.filter(event.getPayload())
+//                        && event.getScope().equals(scope);
+//            }
+//        } catch (Exception e) {
+//            throw new RuntimeException("A checked exception occurred while invoking listener method " + listenerMethod.getName(), e);
+//        }
+//        return supports;
+//    }
 
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
@@ -123,32 +123,7 @@ class MethodListenerWrapper extends AbstractListenerWrapper {
     private boolean isInTopic(Event<?> event) throws InstantiationException, IllegalAccessException {
         EventBusListenerTopic annotation = listenerMethod.getAnnotation(EventBusListenerTopic.class);
         TopicFilter filter = annotation.filter().newInstance();
-        return filter.validTobic(event.getTopic(), annotation.topic());
+        return filter.validTopic(event.getTopic(), annotation.topic());
     }    
-    
-//    @Override
-//    public boolean supports(Event<?> event) {
-//        boolean supports = super.supports(event);
-//        try {
-//            if (listenerMethod.isAnnotationPresent(EventBusListenerMethod.class)) {
-//                EventBusListenerMethod annotation = listenerMethod.getAnnotation(EventBusListenerMethod.class);
-//                EventBusListenerMethodFilter filter = annotation.filter().newInstance();
-////                String target = annotation.target();
-////                boolean isTarget = annotation.targetMatchPrefix() 
-////                        ? event.getTarget().startsWith(target) 
-////                        : target.equals(event.getTarget());
-//                EventScope scope = annotation.scope();
-//                if (scope.equals(EventScope.UNDEFINED)) {
-//                    scope = event.getScope();
-//                }
-//                supports = supports 
-//                        && filter.filter(event.getPayload())
-//                        && event.getScope().equals(scope);
-//            }
-//        } catch (Exception e) {
-//            throw new RuntimeException("A checked exception occurred while invoking listener method " + listenerMethod.getName(), e);
-//        }
-//        return supports;
-//    }
 
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
@@ -98,11 +98,14 @@ class MethodListenerWrapper extends AbstractListenerWrapper {
             if (listenerMethod.isAnnotationPresent(EventBusListenerMethod.class)) {
                 EventBusListenerMethod annotation = listenerMethod.getAnnotation(EventBusListenerMethod.class);
                 EventBusListenerMethodFilter filter = annotation.filter().newInstance();
+                String target = annotation.target();
                 EventScope scope = annotation.scope();
                 if (scope.equals(EventScope.UNDEFINED)) {
                     scope = event.getScope();
                 }
-                supports = supports && filter.filter(event.getPayload()) && event.getScope().equals(scope);
+                supports = supports && filter.filter(event.getPayload())
+                        && event.getScope().equals(scope)
+                        && event.getTarget().startsWith(target);
             }
         } catch (Exception e) {
             throw new RuntimeException("A checked exception occurred while invoking listener method " + listenerMethod.getName(), e);

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
@@ -116,7 +116,7 @@ public abstract class ScopedEventBus implements EventBus, Serializable {
 
     @Override
     public <T> void publish(EventScope scope, String topic, Object sender, T payload) throws UnsupportedOperationException {
-        logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}] int topic [{}]", payload, sender, scope, this, topic);
+        logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}] in topic [{}]", payload, sender, scope, this, topic);
         
         if (eventScope.equals(scope)) {
             publish(topic, sender, payload);

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
@@ -100,17 +100,32 @@ public abstract class ScopedEventBus implements EventBus, Serializable {
 
     @Override
     public <T> void publish(Object sender, T payload) {
-        logger.debug("Publishing payload [{}] from sender [{}] on event bus [{}]", payload, sender, this);
-        listeners.publish(new Event<T>(this, sender, payload));
+        publish("", sender, payload);
+    }
+
+    @Override
+    public <T> void publish(String target, Object sender, T payload) {
+        logger.debug("Publishing payload [{}] from sender [{}] on event bus [{}] to raget  [{}]", payload, sender, this, target);
+        listeners.publish(new Event<T>(this, sender, payload, target));
     }
 
     @Override
     public <T> void publish(EventScope scope, Object sender, T payload) throws UnsupportedOperationException {
-        logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}]", payload, sender, scope, this);
+        publish(scope, "", sender, payload);
+    }
+
+    @Override
+    public <T> void publish(EventScope scope, String target, Object sender, T payload) throws UnsupportedOperationException {
+        logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}] to target [{}]", payload, sender, scope, this, target);
+        
+        if (target == null) {
+        	target = "";
+        }
+        
         if (eventScope.equals(scope)) {
-            publish(sender, payload);
+            publish(target, sender, payload);
         } else if (parentEventBus != null) {
-            parentEventBus.publish(scope, sender, payload);
+            parentEventBus.publish(scope, target, sender, payload);
         } else {
             logger.warn("Could not publish payload with scope [{}] on event bus [{}]", scope, this);
             throw new UnsupportedOperationException("Could not publish event with scope " + scope);

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
@@ -118,10 +118,6 @@ public abstract class ScopedEventBus implements EventBus, Serializable {
     public <T> void publish(EventScope scope, String target, Object sender, T payload) throws UnsupportedOperationException {
         logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}] to target [{}]", payload, sender, scope, this, target);
         
-        if (target == null) {
-        	target = "";
-        }
-        
         if (eventScope.equals(scope)) {
             publish(target, sender, payload);
         } else if (parentEventBus != null) {

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/ScopedEventBus.java
@@ -104,9 +104,9 @@ public abstract class ScopedEventBus implements EventBus, Serializable {
     }
 
     @Override
-    public <T> void publish(String target, Object sender, T payload) {
-        logger.debug("Publishing payload [{}] from sender [{}] on event bus [{}] to raget  [{}]", payload, sender, this, target);
-        listeners.publish(new Event<T>(this, sender, payload, target));
+    public <T> void publish(String topic, Object sender, T payload) {
+        logger.debug("Publishing payload [{}] from sender [{}] on event bus [{}] in topic  [{}]", payload, sender, this, topic);
+        listeners.publish(new Event<T>(this, sender, payload, topic));
     }
 
     @Override
@@ -115,13 +115,13 @@ public abstract class ScopedEventBus implements EventBus, Serializable {
     }
 
     @Override
-    public <T> void publish(EventScope scope, String target, Object sender, T payload) throws UnsupportedOperationException {
-        logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}] to target [{}]", payload, sender, scope, this, target);
+    public <T> void publish(EventScope scope, String topic, Object sender, T payload) throws UnsupportedOperationException {
+        logger.debug("Trying to publish payload [{}] from sender [{}] using scope [{}] on event bus [{}] int topic [{}]", payload, sender, scope, this, topic);
         
         if (eventScope.equals(scope)) {
-            publish(target, sender, payload);
+            publish(topic, sender, payload);
         } else if (parentEventBus != null) {
-            parentEventBus.publish(scope, target, sender, payload);
+            parentEventBus.publish(scope, topic, sender, payload);
         } else {
             logger.warn("Could not publish payload with scope [{}] on event bus [{}]", scope, this);
             throw new UnsupportedOperationException("Could not publish event with scope " + scope);

--- a/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
+++ b/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
@@ -22,7 +22,9 @@ import org.mockito.ArgumentCaptor;
 import org.vaadin.spring.events.Event;
 import org.vaadin.spring.events.EventBusListener;
 import org.vaadin.spring.events.EventScope;
+import org.vaadin.spring.events.HierachyTopicFilter;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
+import org.vaadin.spring.events.annotation.EventBusListenerTopic;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -75,32 +77,38 @@ public class ScopedEventBusTest {
             theIntegerPayload = integerPayload;
         }
         
-        @EventBusListenerMethod(target = "shouldSucceed")
+        @EventBusListenerTopic(topic = "shouldSucceed")
+        @EventBusListenerMethod
         void onStringEventWithTarget(Event<String> stringEvent) {
             theStringEventWithTarget = stringEvent;
         }
 
-        @EventBusListenerMethod(target = "shouldSucceed")
+        @EventBusListenerTopic(topic = "shouldSucceed")
+        @EventBusListenerMethod
         void onStringPayloadEventWithTarget(String stringPayload) {
             theStringPayloadWithTarget = stringPayload;
         }
 
-        @EventBusListenerMethod(target = "shouldSucceed")
+        @EventBusListenerTopic(topic = "shouldSucceed")
+        @EventBusListenerMethod
         void onIntegerEventWithTarget(Event<Integer> integerEvent) {
             theIntegerEventWithTarget = integerEvent;
         }
 
-        @EventBusListenerMethod(target = "shouldSucceed", targetMatchPrefix = true)
+        @EventBusListenerTopic(topic = "shouldSucceed", filter = HierachyTopicFilter.class)
+        @EventBusListenerMethod
         void onIntegerPayloadEventWithTarget(Integer integerPayload) {
             theIntegerPayloadWithTarget = integerPayload;
         }
         
-        @EventBusListenerMethod(target = "shouldFail")
+        @EventBusListenerTopic(topic = "shouldFail")
+        @EventBusListenerMethod
         void onStringPayloadEventWithTargetFail(String stringPayload) {
             theStringPayloadWithTargetFail = stringPayload;
         }
 
-        @EventBusListenerMethod(target = "shouldSucceed.butFail")
+        @EventBusListenerTopic(topic = "shouldSucceed.butFail")
+        @EventBusListenerMethod
         void onIntegerPayloadEventWithTargetFail(Integer integerPayload) {
             theIntegerPayloadWithTargetFail = integerPayload;
         }

--- a/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
+++ b/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
@@ -90,7 +90,7 @@ public class ScopedEventBusTest {
             theIntegerEventWithTarget = integerEvent;
         }
 
-        @EventBusListenerMethod(target = "shouldSucceed")
+        @EventBusListenerMethod(target = "shouldSucceed", targetMatchPrefix = true)
         void onIntegerPayloadEventWithTarget(Integer integerPayload) {
             theIntegerPayloadWithTarget = integerPayload;
         }
@@ -169,14 +169,13 @@ public class ScopedEventBusTest {
 
         assertNull(listener.theStringPayloadWithTargetFail);
         assertNull(listener.theIntegerPayloadWithTargetFail);
+        assertNull(listener.theIntegerEventWithTarget);
         
-        assertNotNull(listener.theIntegerEventWithTarget);
         assertNotNull(listener.theStringEventWithTarget);
         
         assertEquals("Hello World", listener.theStringPayloadWithTarget);
         assertEquals("Hello World", listener.theStringEventWithTarget.getPayload());
         assertEquals(10, listener.theIntegerPayloadWithTarget.intValue());
-        assertEquals(10, listener.theIntegerEventWithTarget.getPayload().intValue());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
We need a simple approach in order to distinguish between Payloads with same content, 

This commit adds two new publich methods with a target paramter (String) to speciefy a target of the event. A method can be marked as target to a speciefic event by setting the target parameter of the EventBusListenerMethod.