### PR TITLE
Add method getWithLocale

### DIFF
--- a/addons/i18n/README.md
+++ b/addons/i18n/README.md
@@ -15,7 +15,16 @@ Example:
  ...
  myLabel = new Label(i18n.get("myMessageKey", "My argument"));
 ```
+It is also possible to specify the Locale, when the bean creation happens before the UI is created. 
 
+Example:
+
+```java
+ @Autowired
+ I18N i18n; 
+ ...
+ myLabel = new Label(i18n.getWithLocale("myMessageKey", Locale.GERMAN, "My argument"));
+```
 # Composite Message Source
 
 A composite message source is an implementation of the Spring ```MessageSource``` interface

--- a/addons/i18n/src/main/java/org/vaadin/spring/i18n/I18N.java
+++ b/addons/i18n/src/main/java/org/vaadin/spring/i18n/I18N.java
@@ -85,8 +85,32 @@ public class I18N {
      */
     public String get(String code, Object... arguments) {
         try {
-            return getMessage(code, arguments);
+            return getMessage(code, null, arguments);
         } catch (NoSuchMessageException ex) {
+            logger.warn("Tried to retrieve message with code [{}] that does not exist", code);
+            return "!" + code;
+        }
+    }
+
+    /**
+     * Tries to resolve the specified message for the given locale.
+     *
+     * @param code      the code to lookup up, such as 'calculator.noRateSet', never {@code null}.
+     * @param arguments Array of arguments that will be filled in for params within the message (params look like "{0}", "{1,date}", "{2,time}"), or {@code null} if none.
+     * @param locale    The Locale for which it is tried to look up the code. Must not be null
+     * @throws IllegalArgumentException if the given Locale is null
+     * @return the resolved message, or the message code prepended with an exclamation mark if the lookup fails.
+     * @see org.springframework.context.ApplicationContext#getMessage(String, Object[], java.util.Locale)
+     * @see java.util.Locale
+     */
+    public String getWithLocale(String code, Locale locale, Object... arguments) {
+        if (locale == null) {
+            throw new IllegalArgumentException("Locale must not be null");
+        }
+        try {
+            return getMessage(code,locale, arguments);
+        }
+        catch (NoSuchMessageException ex) {
             logger.warn("Tried to retrieve message with code [{}] that does not exist", code);
             return "!" + code;
         }
@@ -104,15 +128,16 @@ public class I18N {
      */
     public String getWithDefault(String code, String defaultMessage, Object... arguments) {
         try {
-            return getMessage(code, arguments);
+            return getMessage(code, null, arguments);
         } catch (NoSuchMessageException ex) {
             return defaultMessage;
         }
     }
 
-    private String getMessage(String code, Object... arguments) {
+    private String getMessage(String code, Locale locale, Object... arguments) {
+        Locale actualLocale = locale == null ? getLocale() : locale;
         try {
-            return applicationContext.getMessage(code, arguments, getLocale());
+            return applicationContext.getMessage(code, arguments, actualLocale);
         } catch (NoSuchMessageException ex) {
             if (isRevertToDefaultBundle()) {
                 return applicationContext.getMessage(code, arguments, null);

--- a/addons/i18n/src/test/java/org/vaadin/spring/i18n/I18NTest.java
+++ b/addons/i18n/src/test/java/org/vaadin/spring/i18n/I18NTest.java
@@ -125,6 +125,23 @@ public class I18NTest {
         assertEquals("myDefaultMsg", i18n.getWithDefault("myCode", "myDefaultMsg", "myArg"));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void getWithLocale_LocaleIsNull() {
+        final Locale locale = null;
+        i18n.getWithLocale("myCode", null, new Object[]{"myArg"});
+    }
+
+    @Test
+    public void getWithLocale_passedLocaleIsResolved() {
+        when(applicationContext.getMessage("myCode", new Object[] {"myArg"}, Locale.GERMAN)).thenReturn("myGermanMessage");
+        when(applicationContext.getMessage("myCode", new Object[] {"myArg"}, Locale.US)).thenReturn("myUsMessage");
+        
+        Locale locale = Locale.GERMAN;
+        assertEquals("myGermanMessage", i18n.getWithLocale("myCode", locale, "myArg"));
+        locale = Locale.US;
+        assertEquals("myUsMessage",i18n.getWithLocale("myCode", locale, "myArg"));
+    }
+
     @Test
     public void getLocale_noCurrentUI_defaultLocaleIsReturned() {
         final Locale locale = Locale.getDefault();


### PR DESCRIPTION
In one of our applications, we ran into the follwoing problem: 

We have a custom vaadin component, which is in the @UIScope

In the UI it is possible to change the language. We are setting the value into the VaadinSession and reload the page. 

Therefore our custom component gets recreated, but the UI is null and i18n.get returns the default locale, which is different then the one in the VaadinSession. 

Therefore when the user switches the language, all components which are not @UIScope are using the default locale. All other components are using the one from the UI (which is afaik the same as the VaadinSession)

Although it woul be possible to to extend the private method getLocale, to also check the VaadinServlet locale, we would prefer to add the method getWithLocale to mainain flexibility 