### PR TITLE
Methods should not be empty

### DIFF
--- a/extensions/core/src/main/java/org/vaadin/spring/http/HttpResponseFilter.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/http/HttpResponseFilter.java
@@ -38,7 +38,7 @@ public class HttpResponseFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -60,7 +60,7 @@ public class HttpResponseFilter implements Filter {
 
     @Override
     public void destroy() {		
-
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/VaadinAuthenticationSuccessHandler.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/VaadinAuthenticationSuccessHandler.java
@@ -46,6 +46,7 @@ public interface VaadinAuthenticationSuccessHandler {
 
         @Override
         public void onAuthenticationSuccess(Authentication authentication) throws Exception {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/VaadinLogoutHandler.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/VaadinLogoutHandler.java
@@ -36,6 +36,7 @@ public interface VaadinLogoutHandler {
 
         @Override
         public void onLogout() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/AccessControlView.java
+++ b/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/AccessControlView.java
@@ -84,6 +84,7 @@ public class AccessControlView extends VerticalLayout implements View, ViewAcces
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/NavigationUI.java
+++ b/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/NavigationUI.java
@@ -100,6 +100,7 @@ public class NavigationUI extends UI {
 
         @Override
         public void enter(ViewChangeListener.ViewChangeEvent event) {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/PrototypeScopedView.java
+++ b/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/PrototypeScopedView.java
@@ -71,5 +71,6 @@ public class PrototypeScopedView extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/UIScopedView.java
+++ b/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/UIScopedView.java
@@ -72,5 +72,6 @@ public class UIScopedView extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/ViewScopedView.java
+++ b/samples/navigation-sample/src/main/java/org/vaadin/spring/samples/navigation/ViewScopedView.java
@@ -80,5 +80,6 @@ public class ViewScopedView extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/security-sample-managed/src/main/java/org/vaadin/spring/samples/security/managed/views/AdminView.java
+++ b/samples/security-sample-managed/src/main/java/org/vaadin/spring/samples/security/managed/views/AdminView.java
@@ -56,5 +56,6 @@ public class AdminView extends CustomComponent implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent viewChangeEvent) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/security-sample-managed/src/main/java/org/vaadin/spring/samples/security/managed/views/HomeView.java
+++ b/samples/security-sample-managed/src/main/java/org/vaadin/spring/samples/security/managed/views/HomeView.java
@@ -55,5 +55,6 @@ public class HomeView extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/security-sample-managed/src/main/java/org/vaadin/spring/samples/security/managed/views/UserView.java
+++ b/samples/security-sample-managed/src/main/java/org/vaadin/spring/samples/security/managed/views/UserView.java
@@ -56,5 +56,6 @@ public class UserView extends CustomComponent implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent viewChangeEvent) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/views/AdminView.java
+++ b/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/views/AdminView.java
@@ -56,5 +56,6 @@ public class AdminView extends CustomComponent implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent viewChangeEvent) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/views/HomeView.java
+++ b/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/views/HomeView.java
@@ -55,5 +55,6 @@ public class HomeView extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/views/UserView.java
+++ b/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/views/UserView.java
@@ -56,5 +56,6 @@ public class UserView extends CustomComponent implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent viewChangeEvent) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/FontIconsView1.java
+++ b/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/FontIconsView1.java
@@ -49,5 +49,6 @@ public class FontIconsView1 extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/PlanningView1.java
+++ b/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/PlanningView1.java
@@ -48,5 +48,6 @@ public class PlanningView1 extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/PlanningView2.java
+++ b/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/PlanningView2.java
@@ -49,5 +49,6 @@ public class PlanningView2 extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/ReportingView2.java
+++ b/samples/sidebar-sample/src/main/java/org/vaadin/spring/samples/sidebar/ReportingView2.java
@@ -47,6 +47,6 @@ public class ReportingView2 extends VerticalLayout implements View {
 
     @Override
     public void enter(ViewChangeListener.ViewChangeEvent event) {
-
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1186 Methods should not be empty

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1186 

Please let me know if you have any questions.

Zeeshan Asghar