### PR TITLE
Private methods that don't access instance data should be 'static'

### DIFF
--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
@@ -55,12 +55,12 @@ class MethodListenerWrapper extends AbstractListenerWrapper {
         this.listenerMethod = listenerMethod;
     }
 
-    private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+    private static void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         ois.defaultReadObject();
         // TODO Read listener method info and look up method
     }
 
-    private void writeObject(ObjectOutputStream oos) throws IOException {
+    private static void writeObject(ObjectOutputStream oos) throws IOException {
         oos.defaultWriteObject();
         // TODO Write listener method info
     }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/internal/MethodListenerWrapper.java
@@ -55,12 +55,12 @@ class MethodListenerWrapper extends AbstractListenerWrapper {
         this.listenerMethod = listenerMethod;
     }
 
-    private static void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+    private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
         ois.defaultReadObject();
         // TODO Read listener method info and look up method
     }
 
-    private static void writeObject(ObjectOutputStream oos) throws IOException {
+    private void writeObject(ObjectOutputStream oos) throws IOException {
         oos.defaultWriteObject();
         // TODO Write listener method info
     }

--- a/addons/i18n/src/main/java/org/vaadin/spring/i18n/ResourceBundleMessageProvider.java
+++ b/addons/i18n/src/main/java/org/vaadin/spring/i18n/ResourceBundleMessageProvider.java
@@ -79,7 +79,7 @@ public class ResourceBundleMessageProvider implements MessageProvider {
         }
     }
 
-    private String getString(ResourceBundle bundle, String s) {
+    private static String getString(ResourceBundle bundle, String s) {
         if (bundle == null) {
             return null;
         }
@@ -90,7 +90,7 @@ public class ResourceBundleMessageProvider implements MessageProvider {
         }
     }
 
-    private MessageFormat getMessageFormat(String message, Locale locale) {
+    private static MessageFormat getMessageFormat(String message, Locale locale) {
         if (message == null) {
             return null;
         }

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/DefaultVaadinSharedSecurity.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/DefaultVaadinSharedSecurity.java
@@ -199,7 +199,7 @@ public class DefaultVaadinSharedSecurity extends AbstractVaadinSecurity implemen
         return authentication;
     }
 
-    private WrappedSession getSession() {
+    private static WrappedSession getSession() {
         VaadinSession vaadinSession = VaadinSession.getCurrent();
         if (vaadinSession != null) {
             return vaadinSession.getSession();

--- a/extensions/test/src/main/java/org/vaadin/spring/test/VaadinTestExecutionListener.java
+++ b/extensions/test/src/main/java/org/vaadin/spring/test/VaadinTestExecutionListener.java
@@ -51,7 +51,7 @@ public class VaadinTestExecutionListener extends AbstractTestExecutionListener {
         return AnnotationUtils.findAnnotation(testContext.getTestClass(), VaadinAppConfiguration.class) == null;
     }
 
-    private boolean alreadySetUpVaadinScopes(TestContext testContext) {
+    private static boolean alreadySetUpVaadinScopes(TestContext testContext) {
         return Boolean.TRUE.equals(testContext.getAttribute(SET_UP_SCOPES_ATTRIBUTE));
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2325 'private' methods that don't access instance data should be 'static'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.

Zeeshan Asghar