### PR TITLE
General Code Improvement 1

### DIFF
--- a/addons/i18n/src/main/java/org/vaadin/spring/i18n/I18N.java
+++ b/addons/i18n/src/main/java/org/vaadin/spring/i18n/I18N.java
@@ -202,7 +202,7 @@ public class I18N {
      */
     public Locale getLocale() {
         UI currentUI = UI.getCurrent();
-        Locale locale = (currentUI == null ? null : currentUI.getLocale());
+        Locale locale = currentUI == null ? null : currentUI.getLocale();
         if (locale == null) {
             locale = Locale.getDefault();
         }

--- a/addons/sidebar/src/main/java/org/vaadin/spring/sidebar/components/AbstractSideBar.java
+++ b/addons/sidebar/src/main/java/org/vaadin/spring/sidebar/components/AbstractSideBar.java
@@ -144,7 +144,7 @@ public abstract class AbstractSideBar<CR extends ComponentContainer> extends Cus
                     passedItems.add(candidate);
                 }
             }
-            if (passedItems.size() > 0) {
+            if (!passedItems.isEmpty()) {
                 getSectionComponentFactory().createSection(compositionRoot, section, passedItems);
             }
         }

--- a/extensions/boot/src/main/java/org/vaadin/spring/boot/AtmosphereAutoConfiguration.java
+++ b/extensions/boot/src/main/java/org/vaadin/spring/boot/AtmosphereAutoConfiguration.java
@@ -45,9 +45,7 @@ public class AtmosphereAutoConfiguration {
 
         @Bean
         ServletListenerRegistrationBean<SessionSupport> atmosphereSessionSupport() {
-            ServletListenerRegistrationBean<SessionSupport> bean = new ServletListenerRegistrationBean<SessionSupport>(
-                new SessionSupport());
-            return bean;
+            return new ServletListenerRegistrationBean<SessionSupport>(new SessionSupport());
         }
     }
 }

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/PushSecurityInterceptor.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/PushSecurityInterceptor.java
@@ -62,13 +62,13 @@ public class PushSecurityInterceptor extends AtmosphereInterceptorAdapter {
 
     @Override
     public Action inspect(AtmosphereResource r) {
-        final SecurityContextRepository securityContextRepositoryLocal = getSecurityContextRepository(
+        final SecurityContextRepository securityContextRepo = getSecurityContextRepository(
             r.getAtmosphereConfig().getServletContext());
-        if (securityContextRepositoryLocal.containsContext(r.getRequest())) {
+        if (securityContextRepo.containsContext(r.getRequest())) {
             LOGGER.trace("Loading the security context from the session");
             final HttpRequestResponseHolder requestResponse = new HttpRequestResponseHolder(r.getRequest(),
                 r.getResponse());
-            final SecurityContext securityContext = securityContextRepositoryLocal.loadContext(requestResponse);
+            final SecurityContext securityContext = securityContextRepo.loadContext(requestResponse);
             SecurityContextHolder.setContext(securityContext);
         }
         return Action.CONTINUE;

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/PushSecurityInterceptor.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/PushSecurityInterceptor.java
@@ -62,13 +62,13 @@ public class PushSecurityInterceptor extends AtmosphereInterceptorAdapter {
 
     @Override
     public Action inspect(AtmosphereResource r) {
-        final SecurityContextRepository securityContextRepository = getSecurityContextRepository(
+        final SecurityContextRepository securityContextRepositoryLocal = getSecurityContextRepository(
             r.getAtmosphereConfig().getServletContext());
-        if (securityContextRepository.containsContext(r.getRequest())) {
+        if (securityContextRepositoryLocal.containsContext(r.getRequest())) {
             LOGGER.trace("Loading the security context from the session");
             final HttpRequestResponseHolder requestResponse = new HttpRequestResponseHolder(r.getRequest(),
                 r.getResponse());
-            final SecurityContext securityContext = securityContextRepository.loadContext(requestResponse);
+            final SecurityContext securityContext = securityContextRepositoryLocal.loadContext(requestResponse);
             SecurityContextHolder.setContext(securityContext);
         }
         return Action.CONTINUE;

--- a/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/Application.java
+++ b/samples/security-sample-shared/src/main/java/org/vaadin/spring/samples/security/shared/Application.java
@@ -102,8 +102,7 @@ public class Application {
          */
         @Bean
         public RememberMeServices rememberMeServices() {
-            TokenBasedRememberMeServices services = new TokenBasedRememberMeServices("myAppKey", userDetailsService());
-            return services;
+            return new TokenBasedRememberMeServices("myAppKey", userDetailsService());
         }
 
         /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1488 Local Variables should not be declared and then immediately returned or thrown
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S1155 Collection.isEmpty() should be used to test for emptiness
squid:HiddenFieldCheck Local variables should not shadow class fields

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Zeeshan Asghar