### PR TITLE
Update event bus to support Vaadin Flow and a new Spring version

### DIFF
--- a/addons/eventbus/pom.xml
+++ b/addons/eventbus/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.vaadin.spring</groupId>
@@ -14,6 +15,22 @@
 
     <name>Vaadin4Spring Add-ons - Event Bus</name>
 
+    <properties>
+        <spring.version>5.1.5.RELEASE</spring.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-bom</artifactId>
+                <version>${vaadin.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -23,6 +40,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring</artifactId>
+            <version>${vaadin.platform.spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.vaadin.spring.extensions</groupId>
@@ -36,8 +54,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.1.5.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBus.java
@@ -23,19 +23,17 @@ package org.vaadin.spring.events;
  * <li>Events are scoped</li>
  * </ul>
  * <p>
- * There are four event scopes, and therefore four event bus types (each with their own sub interface):
+ * There are three event scopes, and therefore three event bus types (each with their own sub interface):
  * <ol>
  * <li>{@link EventScope#APPLICATION} events are published to the entire application.</li>
  * <li>{@link EventScope#SESSION} events are published to the current session.</li>
  * <li>{@link EventScope#UI} events are published to the current UI.</li>
- * <li>{@link EventScope#VIEW} events are published to the current view.</li>
  * </ol>
  * <p>
  * The event buses are chained in the following way:
  * <ul>
  * <li>Application events are propagated to the session event bus.</li>
  * <li>Session events are propagated to the UI event bus.</li>
- * <li>UI events are propagated to the view event bus.</li>
  * </ul>
  * Furthermore, {@link org.springframework.context.ApplicationEventPublisher} events can be propagated to any event bus
  * by using {@link org.vaadin.spring.events.support.ApplicationContextEventBroker}.
@@ -271,13 +269,5 @@ public interface EventBus {
      * @see org.vaadin.spring.events.EventScope#UI
      */
     interface UIEventBus extends EventBus {
-    }
-
-    /**
-     * Interface implemented by the view scoped event bus.
-     *
-     * @see org.vaadin.spring.events.EventScope#VIEW
-     */
-    interface ViewEventBus extends EventBus {
     }
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBusAware.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/EventBusAware.java
@@ -56,15 +56,4 @@ public interface EventBusAware extends Aware {
          */
         void setUIEventBus(EventBus.UIEventBus uiEventBus);
     }
-
-    /**
-     * Interface to be implemented by beans that want to get notified of the
-     * view event bus.
-     */
-    interface ViewEventBusAware extends EventBusAware {
-        /**
-         * Sets the view scoped event bus.
-         */
-        void setViewEventBus(EventBus.ViewEventBus viewEventBus);
-    }
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/EventScope.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/EventScope.java
@@ -37,11 +37,6 @@ public enum EventScope {
     UI,
 
     /**
-     * The event is specific to the current view.
-     */
-    VIEW,
-
-    /**
      * Undefined event scope. An internal event scope used only when no scope has been explicitly defined.
      *
      * @see org.vaadin.spring.events.annotation.EventBusListenerMethod#scope()

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/config/EventBusConfiguration.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/config/EventBusConfiguration.java
@@ -15,9 +15,8 @@
  */
 package org.vaadin.spring.events.config;
 
-import com.vaadin.spring.internal.UIScopeImpl;
-import com.vaadin.spring.internal.VaadinSessionScope;
-import com.vaadin.spring.internal.ViewScopeImpl;
+import com.vaadin.flow.spring.scopes.VaadinSessionScope;
+import com.vaadin.flow.spring.scopes.VaadinUIScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -61,30 +60,16 @@ public class EventBusConfiguration {
     }
 
     @Bean
-    @Scope(value = UIScopeImpl.VAADIN_UI_SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
+    @Scope(value = VaadinUIScope.VAADIN_UI_SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
     @EventBusProxy
     EventBus.UIEventBus proxiedUiEventBus() {
         return uiEventBus();
     }
 
     @Bean
-    @Scope(value = UIScopeImpl.VAADIN_UI_SCOPE_NAME, proxyMode = ScopedProxyMode.NO)
+    @Scope(value = VaadinUIScope.VAADIN_UI_SCOPE_NAME, proxyMode = ScopedProxyMode.NO)
     @Primary
     EventBus.UIEventBus uiEventBus() {
         return new ScopedEventBus.DefaultUIEventBus(sessionEventBus());
-    }
-
-    @Bean
-    @Scope(value = ViewScopeImpl.VAADIN_VIEW_SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
-    @EventBusProxy
-    EventBus.ViewEventBus proxiedViewEventBus() {
-        return viewEventBus();
-    }
-
-    @Bean
-    @Scope(value = ViewScopeImpl.VAADIN_VIEW_SCOPE_NAME, proxyMode = ScopedProxyMode.NO)
-    @Primary
-    EventBus.ViewEventBus viewEventBus() {
-        return new ScopedEventBus.DefualtViewEventBus(uiEventBus());
     }
 }

--- a/addons/eventbus/src/main/java/org/vaadin/spring/events/support/VaadinEventBusAwareProcessor.java
+++ b/addons/eventbus/src/main/java/org/vaadin/spring/events/support/VaadinEventBusAwareProcessor.java
@@ -53,14 +53,9 @@ public class VaadinEventBusAwareProcessor implements ApplicationContextAware, Be
         }
 
         if (acc != null) {
-            AccessController.doPrivileged(new PrivilegedAction<Object>() {
-
-                @Override
-                public Object run() {
-                    invokeAwareInterfaces(bean);
-                    return null;
-                }
-
+            AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+                invokeAwareInterfaces(bean);
+                return null;
             }, acc);
         } else {
             invokeAwareInterfaces(bean);
@@ -85,9 +80,6 @@ public class VaadinEventBusAwareProcessor implements ApplicationContextAware, Be
             }
             if (bean instanceof EventBusAware.UIEventBusAware) {
                 ((EventBusAware.UIEventBusAware) bean).setUIEventBus(this.applicationContext.getBean(EventBus.UIEventBus.class));
-            }
-            if (bean instanceof EventBusAware.ViewEventBusAware) {
-                ((EventBusAware.ViewEventBusAware) bean).setViewEventBus(this.applicationContext.getBean(EventBus.ViewEventBus.class));
             }
 
         }

--- a/addons/eventbus/src/test/java/org/vaadin/spring/events/integration/ScopedEventBusIntegrationTest.java
+++ b/addons/eventbus/src/test/java/org/vaadin/spring/events/integration/ScopedEventBusIntegrationTest.java
@@ -1,0 +1,149 @@
+package org.vaadin.spring.events.integration;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.spring.SpringVaadinSession;
+import com.vaadin.flow.spring.annotation.EnableVaadin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.vaadin.spring.events.EventBus;
+import org.vaadin.spring.events.config.EventBusConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for the different event bus scopes
+ *
+ * @author erik@vaadin.com
+ * @since 14/02/2019
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {EventBusConfiguration.class, ScopedEventBusIntegrationTest.Config.class})
+class ScopedEventBusIntegrationTest {
+
+    @Configuration
+    @EnableVaadin
+    public static class Config {
+    }
+
+    public static class TestSession extends SpringVaadinSession {
+        TestSession() {
+            super(Mockito.mock(VaadinService.class));
+        }
+
+        @Override
+        public boolean hasLock() {
+            return true;
+        }
+
+        @Override
+        public void lock() {
+        }
+
+        @Override
+        public void unlock() {
+        }
+    }
+
+    private static int uiId = 0;
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        VaadinSession.setCurrent(new TestSession());
+        UI.setCurrent(createMockUI());
+    }
+
+    @Test
+    void testSameUIReturnsSameUIEventBus() {
+        EventBus.UIEventBus uiBus = applicationContext.getBean(EventBus.UIEventBus.class);
+        EventBus.UIEventBus uiBus2 = applicationContext.getBean(EventBus.UIEventBus.class);
+        assertEquals(uiBus, uiBus2, "Same UI should return same UIEventBus");
+    }
+
+    @Test
+    void testDifferentUIReturnsDifferentUIEventBus() {
+        EventBus.UIEventBus uiBus = applicationContext.getBean(EventBus.UIEventBus.class);
+        UI.setCurrent(createMockUI());
+        EventBus.UIEventBus uiBus2 = applicationContext.getBean(EventBus.UIEventBus.class);
+        assertNotEquals(uiBus, uiBus2, "Different UIs should return different UIEventBuses");
+    }
+
+    @Test
+    void testNoUIThrowsBeanCreationException() {
+        UI.setCurrent(null);
+        assertThrows(BeanCreationException.class, () -> applicationContext.getBean(EventBus.UIEventBus.class));
+    }
+
+    @Test
+    void testSameSessionReturnsSameSessionEventBus() {
+        EventBus.SessionEventBus sessionBus = applicationContext.getBean(EventBus.SessionEventBus.class);
+        EventBus.SessionEventBus sessionBus2 = applicationContext.getBean(EventBus.SessionEventBus.class);
+        assertEquals(sessionBus, sessionBus2, "Same session should return same SessionEventBus");
+    }
+
+    @Test
+    void testSameSessionDifferentUIReturnsSameSessionEventBus() {
+        EventBus.SessionEventBus sessionBus = applicationContext.getBean(EventBus.SessionEventBus.class);
+        UI.setCurrent(createMockUI());
+        EventBus.SessionEventBus sessionBus2 = applicationContext.getBean(EventBus.SessionEventBus.class);
+        assertEquals(sessionBus, sessionBus2, "Same session different UIs should return same SessionEventBus");
+    }
+
+    @Test
+    void testDifferentSessionsReturnDifferentSessionEventBuses() {
+        EventBus.SessionEventBus sessionBus = applicationContext.getBean(EventBus.SessionEventBus.class);
+        VaadinSession.setCurrent(new TestSession());
+        EventBus.SessionEventBus sessionBus2 = applicationContext.getBean(EventBus.SessionEventBus.class);
+        assertNotEquals(sessionBus, sessionBus2, "Different sessions should return different SessionEventBuses");
+    }
+
+    @Test
+    void sameApplicationReturnsSameApplicationEventBus() {
+        EventBus.ApplicationEventBus applicationBus = applicationContext.getBean(EventBus.ApplicationEventBus.class);
+        EventBus.ApplicationEventBus applicationBus2 = applicationContext.getBean(EventBus.ApplicationEventBus.class);
+        assertEquals(applicationBus, applicationBus2, "ApplicationEventBus should always be the same");
+    }
+
+    @Test
+    void sameApplicationDifferentUIReturnsSameApplicationEventBus() {
+        EventBus.ApplicationEventBus applicationBus = applicationContext.getBean(EventBus.ApplicationEventBus.class);
+        UI.setCurrent(createMockUI());
+        EventBus.ApplicationEventBus applicationBus2 = applicationContext.getBean(EventBus.ApplicationEventBus.class);
+        assertEquals(applicationBus, applicationBus2, "ApplicationEventBus should always be the same");
+    }
+
+    @Test
+    void sameApplicationDifferentSessionReturnsSameApplicationEventBus() {
+        EventBus.ApplicationEventBus applicationBus = applicationContext.getBean(EventBus.ApplicationEventBus.class);
+        VaadinSession.setCurrent(new TestSession());
+        EventBus.ApplicationEventBus applicationBus2 = applicationContext.getBean(EventBus.ApplicationEventBus.class);
+        assertEquals(applicationBus, applicationBus2, "ApplicationEventBus should always be the same");
+    }
+
+    /**
+     * Creates a new mock UI with a unique ID
+     */
+    private UI createMockUI() {
+        UI ui = Mockito.mock(UI.class);
+        int id = uiId++;
+        when(ui.getUIId()).thenReturn(id);
+        return ui;
+    }
+}

--- a/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
+++ b/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
@@ -15,9 +15,9 @@
  */
 package org.vaadin.spring.events.internal;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.vaadin.spring.events.Event;
 import org.vaadin.spring.events.EventBusListener;
@@ -26,7 +26,7 @@ import org.vaadin.spring.events.HierachyTopicFilter;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 import org.vaadin.spring.events.annotation.EventBusListenerTopic;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -176,13 +176,13 @@ public class ScopedEventBusTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         applicationEventBus = new ScopedEventBus.DefaultApplicationEventBus();
         sessionEventBus = new ScopedEventBus.DefaultSessionEventBus(applicationEventBus);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         sessionEventBus.destroy();
         applicationEventBus.destroy();
@@ -405,19 +405,19 @@ public class ScopedEventBusTest {
         assertNotNull(stringListener.theStringEvent);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscribeAndPublishWithListenerMethodsAndTooFewParameters() {
-        sessionEventBus.subscribe(new InvalidListener1());
+        assertThrows(IllegalArgumentException.class, () -> sessionEventBus.subscribe(new InvalidListener1()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscribeAndPublishWithListenerMethodsAndTooManyParameters() {
-        sessionEventBus.subscribe(new InvalidListener2());
+        assertThrows(IllegalArgumentException.class, () -> sessionEventBus.subscribe(new InvalidListener2()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testPublishToInvalidScope() {
-        applicationEventBus.publish(EventScope.SESSION, this, "fail");
+        assertThrows(UnsupportedOperationException.class, () -> applicationEventBus.publish(EventScope.SESSION, this, "fail"));
     }
 
     @Test

--- a/addons/eventbus/src/test/java/org/vaadin/spring/events/support/ApplicationContextEventBrokerTest.java
+++ b/addons/eventbus/src/test/java/org/vaadin/spring/events/support/ApplicationContextEventBrokerTest.java
@@ -15,7 +15,7 @@
  */
 package org.vaadin.spring.events.support;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEvent;
 import org.vaadin.spring.events.EventBus;
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
         <project.build.encoding>UTF-8</project.build.encoding>
         <project.build.target>1.8</project.build.target>
         <project.build.source>1.8</project.build.source>
+        <vaadin.platform.version>12.0.5</vaadin.platform.version>
+        <vaadin.platform.spring.version>10.1.1</vaadin.platform.spring.version>
         <vaadin.version>8.0.2</vaadin.version>
         <vaadin-touchkit.version>4.0.0</vaadin-touchkit.version>
         <vaadin-spring.version>2.0.0</vaadin-spring.version>


### PR DESCRIPTION
Update the event bus to Spring 5 and Vaadin Flow.

EventBus tests pass if run from IntelliJ, not if run from command line.

I tested this in a Vaadin platform project, seems to work, but I needed to explicitly import the `EventBusConfiguration` class.

Obviously I needed to re-define some versions in the eventbus module.

Opinions on this?