### PR TITLE
Update eventBus addon classes and test class. Update extension classes to Flow versions.

### DIFF
--- a/addons/eventbus/README.md
+++ b/addons/eventbus/README.md
@@ -35,6 +35,15 @@ creating a singleton instance of ```ApplicationContextEventBroker```:
      return new ApplicationContextEventBroker(eventBus);
  }
 ```    
+# Enable Event Bus
+
+On configuration class add annotation:
+```java
+ @EnableEventBus
+ @Configuration
+ public class MyConfiguration {...}
+```
+
 
 # Event Bus Topics
 Events can be published with an optional string based topic. This will distinguish which listener methods will be called. Therefore, when it's the intent to use topics, a topic must be provided when publishing events and at the listener methods.

--- a/addons/eventbus/pom.xml
+++ b/addons/eventbus/pom.xml
@@ -54,15 +54,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.0</version>
-            <scope>test</scope>
-        </dependency>
+	        <groupId>org.junit.jupiter</groupId>
+	        <artifactId>junit-jupiter-engine</artifactId>
+	        <version>5.4.0</version>
+	        <scope>test</scope>
+	    </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.1.5.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -71,4 +70,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <build>
+    	<plugins>
+    		<plugin>
+    			 <artifactId>maven-surefire-plugin</artifactId>
+	            <version>2.19.1</version>
+	            <dependencies>
+	                <dependency>
+	                    <groupId>org.junit.platform</groupId>
+	                    <artifactId>junit-platform-surefire-provider</artifactId>
+	                    <version>1.1.0</version>
+	                </dependency>
+	            </dependencies>
+    		</plugin>
+    	</plugins>
+    </build>
 </project>

--- a/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
+++ b/addons/eventbus/src/test/java/org/vaadin/spring/events/internal/ScopedEventBusTest.java
@@ -18,13 +18,17 @@ package org.vaadin.spring.events.internal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.vaadin.spring.events.Event;
 import org.vaadin.spring.events.EventBusListener;
 import org.vaadin.spring.events.EventScope;
 import org.vaadin.spring.events.HierachyTopicFilter;
 import org.vaadin.spring.events.annotation.EventBusListenerMethod;
 import org.vaadin.spring.events.annotation.EventBusListenerTopic;
+import org.vaadin.spring.events.config.EventBusConfiguration;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -34,6 +38,8 @@ import static org.mockito.Mockito.*;
  *
  * @author Petter Holmström (petter@vaadin.com)
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { EventBusConfiguration.class })
 public class ScopedEventBusTest {
 
     ScopedEventBus.DefaultApplicationEventBus applicationEventBus;

--- a/extensions/boot/src/main/java/org/vaadin/spring/boot/ExtensionsAutoConfiguration.java
+++ b/extensions/boot/src/main/java/org/vaadin/spring/boot/ExtensionsAutoConfiguration.java
@@ -15,8 +15,7 @@
  */
 package org.vaadin.spring.boot;
 
-import com.vaadin.server.VaadinServlet;
-import com.vaadin.spring.boot.VaadinAutoConfiguration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -29,6 +28,7 @@ import org.vaadin.spring.annotation.EnableVaadinExtensions;
 import org.vaadin.spring.config.VaadinExtensionsConfiguration;
 import org.vaadin.spring.servlet.Vaadin4SpringServlet;
 
+import com.vaadin.flow.server.VaadinServlet;
 /**
  * Auto configuration for Vaadin4Spring core extensions.
  *

--- a/extensions/boot/src/test/java/org/vaadin/spring/boot/CustomServletOverrideTest.java
+++ b/extensions/boot/src/test/java/org/vaadin/spring/boot/CustomServletOverrideTest.java
@@ -15,7 +15,6 @@
  */
 package org.vaadin.spring.boot;
 
-import com.vaadin.server.VaadinServlet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -25,6 +24,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+
+import com.vaadin.flow.server.VaadinServlet;
 
 import javax.annotation.Resource;
 import javax.servlet.Servlet;

--- a/extensions/core/src/main/java/org/vaadin/spring/config/VaadinExtensionsConfiguration.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/config/VaadinExtensionsConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.vaadin.spring.config;
 
-import com.vaadin.spring.annotation.EnableVaadin;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -29,6 +28,8 @@ import org.vaadin.spring.http.HttpResponseFactory;
 import org.vaadin.spring.http.HttpResponseFilter;
 import org.vaadin.spring.http.HttpService;
 import org.vaadin.spring.http.VaadinHttpService;
+
+import com.vaadin.flow.spring.annotation.EnableVaadin;
 
 import javax.servlet.ServletContext;
 

--- a/extensions/core/src/main/java/org/vaadin/spring/context/VaadinServiceFactory.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/context/VaadinServiceFactory.java
@@ -1,8 +1,9 @@
 package org.vaadin.spring.context;
 
-import com.vaadin.server.VaadinService;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.NamedBean;
+
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Factory bean that makes the current {@link com.vaadin.server.VaadinService} available

--- a/extensions/core/src/main/java/org/vaadin/spring/context/VaadinSessionFactory.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/context/VaadinSessionFactory.java
@@ -15,9 +15,10 @@
  */
 package org.vaadin.spring.context;
 
-import com.vaadin.server.VaadinSession;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.NamedBean;
+
+import com.vaadin.flow.server.VaadinSession;
 
 /**
  * Factory bean that makes the current {@link com.vaadin.server.VaadinSession} available

--- a/extensions/core/src/main/java/org/vaadin/spring/request/VaadinRequestEndListener.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/request/VaadinRequestEndListener.java
@@ -15,9 +15,9 @@
  */
 package org.vaadin.spring.request;
 
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinSession;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
 
 /**
  * Interface to be implemented by managed (singleton) beans that want to be notified when a Vaadin request ends.

--- a/extensions/core/src/main/java/org/vaadin/spring/request/VaadinRequestStartListener.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/request/VaadinRequestStartListener.java
@@ -15,8 +15,8 @@
  */
 package org.vaadin.spring.request;
 
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
 
 /**
  * Interface to be implemented by managed (singleton) beans that want to be notified when a Vaadin request starts.

--- a/extensions/core/src/main/java/org/vaadin/spring/servlet/Vaadin4SpringServlet.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/servlet/Vaadin4SpringServlet.java
@@ -27,11 +27,18 @@ import javax.servlet.ServletException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
-import com.vaadin.server.*;
-import com.vaadin.spring.server.SpringVaadinServlet;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.ServiceDestroyListener;
+import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.SessionDestroyListener;
+import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.SystemMessagesProvider;
+import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.flow.spring.SpringServlet;
 
 /**
  * An extended version of {@link com.vaadin.spring.server.SpringVaadinServlet} that provides the following additional
@@ -53,11 +60,13 @@ import com.vaadin.spring.server.SpringVaadinServlet;
  * @author Petter Holmström (petter@vaadin.com)
  * @see org.vaadin.spring.servlet.Vaadin4SpringServletService
  */
-public class Vaadin4SpringServlet extends SpringVaadinServlet {
+public class Vaadin4SpringServlet extends SpringServlet {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Vaadin4SpringServlet.class);
 
-    public Vaadin4SpringServlet() {
+    public Vaadin4SpringServlet(ApplicationContext context,
+            boolean forwardingEnforced) {
+    	super(context, forwardingEnforced);
         LOGGER.info("Using custom Vaadin4Spring servlet");
     }
 
@@ -69,8 +78,7 @@ public class Vaadin4SpringServlet extends SpringVaadinServlet {
     @Override
     protected VaadinServletService createServletService(DeploymentConfiguration deploymentConfiguration)
         throws ServiceException {
-        final Vaadin4SpringServletService service = new Vaadin4SpringServletService(this, deploymentConfiguration,
-            getServiceUrlPath());
+        final Vaadin4SpringServletService service = new Vaadin4SpringServletService(this, deploymentConfiguration);
         service.init();
         return service;
     }

--- a/extensions/core/src/main/java/org/vaadin/spring/servlet/Vaadin4SpringServletService.java
+++ b/extensions/core/src/main/java/org/vaadin/spring/servlet/Vaadin4SpringServletService.java
@@ -15,13 +15,7 @@
  */
 package org.vaadin.spring.servlet;
 
-import com.vaadin.server.DeploymentConfiguration;
-import com.vaadin.server.ServiceException;
-import com.vaadin.server.VaadinRequest;
-import com.vaadin.server.VaadinResponse;
-import com.vaadin.server.VaadinServlet;
-import com.vaadin.server.VaadinSession;
-import com.vaadin.spring.server.SpringVaadinServletService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.WebApplicationContext;
@@ -29,9 +23,17 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.vaadin.spring.request.VaadinRequestEndListener;
 import org.vaadin.spring.request.VaadinRequestStartListener;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.spring.SpringVaadinServletService;
+
 /**
- * Extended version of {@link com.vaadin.spring.server.SpringVaadinServletService} that adds support
- * for {@link org.vaadin.spring.request.VaadinRequestStartListener}s and {@link org.vaadin.spring.request.VaadinRequestEndListener}s.
+ * Extended version of {@link com.vaadin.flow.spring.SpringVaadinServletService} that adds support
+ * for {@link VaadinRequestStartListener}s and {@link org.vaadin.spring.request.VaadinRequestEndListener}s.
  *
  * @author Petter Holmström (petter@vaadin.com)
  */
@@ -50,10 +52,11 @@ public class Vaadin4SpringServletService extends SpringVaadinServletService {
      *                                with a slash) or null for default
      * @throws ServiceException
      */
-    public Vaadin4SpringServletService(VaadinServlet servlet, DeploymentConfiguration deploymentConfiguration, String serviceUrl) throws ServiceException {
-        super(servlet, deploymentConfiguration, serviceUrl);
+    public Vaadin4SpringServletService(VaadinServlet servlet, DeploymentConfiguration deploymentConfiguration) throws ServiceException {
+        super(servlet, deploymentConfiguration, WebApplicationContextUtils.getWebApplicationContext(servlet.getServletContext()));
+        this.applicationContext = WebApplicationContextUtils.getWebApplicationContext(servlet.getServletContext());
         logger.info("Using custom Vaadin4Spring servlet service");
-        applicationContext = WebApplicationContextUtils.getWebApplicationContext(servlet.getServletContext());
+//        applicationContext = WebApplicationContextUtils.getWebApplicationContext(servlet.getServletContext());
     }
 
     @Override

--- a/extensions/security/src/main/java/org/vaadin/spring/security/navigation/PreAuthorizeViewInstanceAccessControl.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/navigation/PreAuthorizeViewInstanceAccessControl.java
@@ -15,9 +15,9 @@
  */
 package org.vaadin.spring.security.navigation;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.navigator.View;
 import com.vaadin.spring.access.ViewInstanceAccessControl;
-import com.vaadin.ui.UI;
 import org.aopalliance.intercept.MethodInvocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/DefaultVaadinSharedSecurity.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/DefaultVaadinSharedSecurity.java
@@ -34,8 +34,8 @@ import org.springframework.util.Assert;
 import org.vaadin.spring.http.HttpService;
 import org.vaadin.spring.security.AbstractVaadinSecurity;
 
-import com.vaadin.server.VaadinSession;
-import com.vaadin.server.WrappedSession;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.WrappedSession;
 
 /**
  * Default implementation of {@link VaadinSharedSecurity}.

--- a/extensions/security/src/main/java/org/vaadin/spring/security/shared/VaadinSessionClosingLogoutHandler.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/shared/VaadinSessionClosingLogoutHandler.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 
-import com.vaadin.server.VaadinSession;
+import com.vaadin.flow.server.VaadinSession;
+
 
 /**
  * A {@link LogoutHandler} that closes all the Vaadin sessions in the current HTTP servlet session.

--- a/extensions/security/src/main/java/org/vaadin/spring/security/util/SuccessfulLoginEvent.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/util/SuccessfulLoginEvent.java
@@ -15,9 +15,10 @@
  */
 package org.vaadin.spring.security.util;
 
-import com.vaadin.ui.UI;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.security.core.Authentication;
+
+import com.vaadin.flow.component.UI;
 
 /**
  * Event that can be published using either the Spring event publisher or the Vaadin4Spring event bus when a user

--- a/extensions/security/src/main/java/org/vaadin/spring/security/web/DefaultVaadinRedirectStrategy.java
+++ b/extensions/security/src/main/java/org/vaadin/spring/security/web/DefaultVaadinRedirectStrategy.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.web.util.UrlUtils;
 
-import com.vaadin.ui.UI;
+import com.vaadin.flow.component.UI;
 
 /**
  * Default implementation of {@link VaadinRedirectStrategy}. Based on
@@ -44,7 +44,8 @@ public class DefaultVaadinRedirectStrategy implements VaadinRedirectStrategy {
     public void sendRedirect(String url) {
         final String redirectUrl = calculateRedirectUrl(servletContext.getContextPath(), url);
         LOGGER.debug("Redirecting to [" + redirectUrl + "]");
-        UI.getCurrent().getPage().setLocation(redirectUrl);
+        // TODO check change from redirectUrl to url (relative path)
+        UI.getCurrent().navigate(redirectUrl);
     }
 
     private String calculateRedirectUrl(String contextPath, String url) {


### PR DESCRIPTION
Fixed eventBus test configuration for junit 5.
Updated extension classes to be able to create a dependency for eventbus addon (vaadin-spring-ext-core).
Few classes still do not compile in etx-boot and ext-security.

UI Event Bus tested on real app, works with changes in this pull request.